### PR TITLE
Bugfix: Extra paren in CI command

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -8,7 +8,7 @@ name: Commands
 
 jobs:
   document:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/document') }}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/document') }}
     name: document
     runs-on: ubuntu-latest
     env:
@@ -45,7 +45,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   style:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/style') }}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/style') }}
     name: style
     runs-on: ubuntu-latest
     env:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Bugs fixed in the updated, faster pre-commit checks
 * Updated, faster pre-commit checks
 * Azure Blob file download utilities
 * CI running on Ubuntu only & working pkgdown deploy to Github Pages


### PR DESCRIPTION
Error:
> Invalid workflow file: .github/workflows/pr-commands.yaml#L11
The workflow is not valid. .github/workflows/pr-commands.yaml (Line: 11, Col: 9): Unexpected symbol: ')'. Located at position 203 within expression: github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/document') .github/workflows/pr-commands.yaml (Line: 48, Col: 9): Unexpected symbol: ')'. Located at position 203 within expression: github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') || github.event.comment.author_association == 'CONTRIBUTOR') && startsWith(github.event.comment.body, '/style')
