### PR TITLE
Fix read_data incomplete return error messages

### DIFF
--- a/R/read_data.R
+++ b/R/read_data.R
@@ -132,15 +132,15 @@ read_data <- function(data_path,
     )
   }
   # Warn for incomplete return
+  n_rows_expected <- as.Date(max_reference_date) - as.Date(min_reference_date) + 1
   if (
-    nrow(df) != as.Date(max_reference_date) - as.Date(min_reference_date) + 1
+    nrow(df) != n_rows_expected
   ) {
-    n_rows_expected <- as.Date(max_reference_date) - as.Date(min_reference_date)
-    expected_dates <- format(seq.Date(
+    expected_dates <- seq.Date(
       from = as.Date(min_reference_date),
       to = as.Date(max_reference_date),
       by = "day"
-    ), "%Y-%m-%d")
+    )
     missing_dates <- setdiff(expected_dates, df[["reference_date"]])
     cli::cli_warn(
       c(


### PR DESCRIPTION
Fixes two bugs:

1. The expected rows in the error message were off by one compared to the expected rows in the error check.
2. If any rows were missing, all of the `reference_date`s would be reported as missing because `expected_dates` and `df[["reference_date"]]` were of different types.