### PR TITLE
Take 2: Fix `read_data()` incomplete return warning message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Fix bug in warning message for incomplete data read (h/t @damonbayer)
 * Fit EpiNow2 model using params and fixed seed
 * Removed `.vscode` folder from repo
 * Read and apply exclusions to case data

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -132,7 +132,9 @@ read_data <- function(data_path,
     )
   }
   # Warn for incomplete return
-  n_rows_expected <- as.Date(max_reference_date) - as.Date(min_reference_date) + 1
+  n_rows_expected <- as.Date(max_reference_date) -
+    as.Date(min_reference_date) +
+    1
   if (
     nrow(df) != n_rows_expected
   ) {
@@ -141,13 +143,19 @@ read_data <- function(data_path,
       to = as.Date(max_reference_date),
       by = "day"
     )
-    missing_dates <- setdiff(expected_dates, df[["reference_date"]])
+    missing_dates <- stringify_date(
+      # Setdiff strips the date attribute from the objects; re-add it so that we
+      # can pretty-format the date for printing
+      as.Date(
+        setdiff(expected_dates, df[["reference_date"]])
+      )
+    )
     cli::cli_warn(
       c(
         "Incomplete number of rows returned",
         "Expected {.val {n_rows_expected}} rows",
-        "Observed {.val {nrow(df)}} rows ",
-        "Missing reference date(s): {.val {missing_dates}}"
+        "Observed {.val {nrow(df)}} rows",
+        "Missing reference date(s): {missing_dates}"
       ),
       class = "incomplete_return"
     )

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -132,15 +132,15 @@ read_data <- function(data_path,
     )
   }
   # Warn for incomplete return
+  n_rows_expected <- as.Date(max_reference_date) - as.Date(min_reference_date) + 1
   if (
-    nrow(df) != as.Date(max_reference_date) - as.Date(min_reference_date) + 1
+    nrow(df) != n_rows_expected
   ) {
-    n_rows_expected <- as.Date(max_reference_date) - as.Date(min_reference_date)
-    expected_dates <- format(seq.Date(
+    expected_dates <- seq.Date(
       from = as.Date(min_reference_date),
       to = as.Date(max_reference_date),
       by = "day"
-    ), "%Y-%m-%d")
+    )
     missing_dates <- setdiff(expected_dates, df[["reference_date"]])
     cli::cli_warn(
       c(

--- a/tests/testthat/_snaps/read_data.md
+++ b/tests/testthat/_snaps/read_data.md
@@ -1,0 +1,7 @@
+# Incomplete return throws warning
+
+    Incomplete number of rows returned
+    Expected 23 rows
+    Observed 21 rows
+    Missing reference date(s): 2022-12-31 and 2023-01-01
+

--- a/tests/testthat/test-read_data.R
+++ b/tests/testthat/test-read_data.R
@@ -98,12 +98,13 @@ test_that("An invalid query throws a wrapped error", {
 test_that("Incomplete return throws warning", {
   data_path <- test_path("data/test_data.parquet")
 
-  expect_warning(
+  # Two missing dates
+  expect_snapshot_warning(
     read_data(data_path,
       disease = "test",
       state_abb = "test",
       report_date = "2023-10-28",
-      min_reference_date = "2022-12-01",
+      min_reference_date = "2022-12-31",
       max_reference_date = "2023-01-22"
     ),
     class = "incomplete_return"


### PR DESCRIPTION
From @damonbayer:

> Fixes two bugs:
>
>The expected rows in the error message were off by one compared to the expected rows in the error check.
If any rows were missing, all of the reference_dates would be reported as missing because expected_dates and df[["reference_date"]] were of different types.

I add the additional changes to 20d77fc6c95b3a794c3971884652af64e75f662a:

1. Fix the lint error in the creation of `missing_dates`
2. Reformat `missing_dates` to a string so that the missing dates are
  pretty-printed. They're printed as an int if they're left as dates.
3. Update the test for this warning to a classed **snapshot** test.
  This change should prevent regression of the warning message.