### PR TITLE
Explicit date casting in queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,3 +17,4 @@
 * Updated DESCRIPTION and added guidelines for package authorship
 * Set up README with explanation of purpose and scope
 * Removed `add.R` placeholder
+* Fix bugs in date casting caused by DuckDB v1.1.1 release

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -141,7 +141,7 @@ read_interval_pmf <- function(path,
       AND parameter = ?
       AND disease = ?
       AND start_date < ? :: DATE
-      AND (end_date > ? OR end_date IS NULL)
+      AND (CAST(end_date AS DATE) > ? :: DATE OR end_date IS NULL)
     "
   parameters <- list(
     path,

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -71,9 +71,9 @@ read_data <- function(data_path,
     WHERE 1=1
       AND disease = ?
       AND metric = 'count_ed_visits'
-      AND reference_date >= ?
-      AND reference_date <= ?
-      AND report_date = ?
+      AND reference_date >= ? :: DATE
+      AND reference_date <= ? :: DATE
+      AND report_date = ? :: DATE
     GROUP BY reference_date, report_date, disease
     ORDER BY reference_date
    "
@@ -90,9 +90,9 @@ read_data <- function(data_path,
   WHERE 1=1
     AND disease = ?
     AND metric = 'count_ed_visits'
-    AND reference_date >= ?
-    AND reference_date <= ?
-    AND report_date = ?
+    AND reference_date >= ? :: DATE
+    AND reference_date <= ? :: DATE
+    AND report_date = ? :: DATE
     AND geo_value = ?
   GROUP BY geo_value, reference_date, report_date, disease
   ORDER BY reference_date


### PR DESCRIPTION
To fix test failures caused by DuckDB v1.1.1 release
