### PR TITLE
Read from new parameters schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,3 +23,4 @@
 * Write outputs to file
 * Specify number of samples draws with `iter_sampling`
 * Fix NOTE from missing variable name used with NSE
+* Read from new parameters schema

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -162,7 +162,7 @@ read_interval_pmf <- function(path,
   # Handle state separately because can't use `=` for NULL comparison and
   # DBI::dbBind() can't parameterize a query after IS
   if (rlang::is_na(group) || rlang::is_null(group)) {
-    query <- paste(query, "AND geo_value IS NULL;")
+    query <- paste(query, "AND geo_value IS NULL")
   } else {
     query <- paste(query, "AND geo_value = ?")
     parameters <- c(parameters, list(group))

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -9,8 +9,17 @@
 #'   date. Set for the current date for the most up-to-to date version of the
 #'   parameters and set to an earlier date to use parameters from an earlier
 #'   time period.
-#' @param group Used only for parameters with a state-level estimate (i.e., only
-#'   right-truncation). The two-letter uppercase state abbreviation.
+#' @param group An optional parameter to subset the query to a parameter with a
+#'   particular two-letter state abbrevation. Right now, the only parameter with
+#'   state-specific estimates is `right_truncation`.
+#' @param report_date An optional parameter to subset the query to a parameter
+#'   on or before a particular `report_date`. Right now, the only parameter with
+#'   report date-specific estimates is `right_truncation`. Note that this
+#'   is similar to, but different from `as_of_date`. The `report_date` is used
+#'   to select the particular value of a time-varying estimate. This estimate
+#'   may itself be regenerated over time (e.g., as new data becomes available or
+#'   with a methodological update). We can pull the estimate for date
+#'   `report_date` as generated on date `as_of_date`.
 #'
 #' @return A named list with three PMFs. The list elements are named
 #'   `generation_interval`, `delay_interval`, and `right_truncation`. If a path
@@ -27,7 +36,8 @@ read_disease_parameters <- function(
     right_truncation_path,
     disease,
     as_of_date,
-    group) {
+    group,
+    report_date) {
   generation_interval <- read_interval_pmf(
     path = generation_interval_path,
     disease = disease,
@@ -55,7 +65,8 @@ read_disease_parameters <- function(
       disease = disease,
       as_of_date = as_of_date,
       parameter = "right_truncation",
-      group = group
+      group = group,
+      report_date = report_date
     )
   } else {
     cli::cli_alert_warning(
@@ -99,12 +110,8 @@ path_is_specified <- function(path) {
 #' https://en.wikipedia.org/wiki/Slowly_changing_dimension#Type_2:_add_new_row
 #'
 #' @param path A path to a local file
-#' @param disease One of "COVID-19" or "Influenza"
-#' @param as_of_date The parameters "as of" the date of the model run
 #' @param parameter One of "generation interval", "delay", or "right-truncation
-#' @param group An optional parameter to subset the query to a parameter with a
-#'   particular two-letter state abbrevation. Right now, the only parameter with
-#'   state-specific estimates is `right-truncation`.
+#' @inheritParams read_disease_parameters
 #'
 #' @return A PMF vector
 #' @export
@@ -116,7 +123,8 @@ read_interval_pmf <- function(path,
                                 "delay",
                                 "right_truncation"
                               ),
-                              group = NA) {
+                              group = NA,
+                              report_date = NA) {
   ###################
   # Validate input
   rlang::arg_match(parameter)
@@ -135,7 +143,7 @@ read_interval_pmf <- function(path,
   # Prepare query
 
   query <- "
-    SELECT value
+    SELECT value, reference_date
     FROM read_parquet(?)
     WHERE 1=1
       AND parameter = ?
@@ -158,6 +166,15 @@ read_interval_pmf <- function(path,
   } else {
     query <- paste(query, "AND geo_value = ?")
     parameters <- c(parameters, list(group))
+  }
+  if (parameter == "right_truncation") {
+    query <- paste(query, "AND (
+                             reference_date <= ? :: DATE
+                             OR reference_date IS NULL
+                           )
+                           ORDER BY reference_date DESC
+                           LIMIT 1")
+    parameters <- c(parameters, list(report_date))
   }
 
   ################
@@ -183,7 +200,41 @@ read_interval_pmf <- function(path,
   )
   DBI::dbDisconnect(con)
 
+  pmf <- check_returned_pmf(
+    pmf_df,
+    parameter,
+    disease,
+    as_of_date,
+    group,
+    report_date,
+    path
+  )
 
+  cli::cli_alert_success("{.arg {parameter}} loaded")
+
+  return(pmf)
+}
+
+#' Run validity checks on the PMF returned from the file
+#'
+#' We're treating this input as possibly invalid because it's from an
+#' external file. We're still updating the schema and process ands has
+#' been a frequent source of problems. We want to be alert to any
+#' unexpexted changes in schema or format.
+#'
+#' @param pmf_df A dataframe with columns `value` and `reference_date`.
+#' @inheritParams read_interval_pmf
+#'
+#' @return The unpacked `value` column, which is a valid PMF
+#' @noRd
+check_returned_pmf <- function(
+    pmf_df,
+    parameter,
+    disease,
+    as_of_date,
+    group,
+    report_date,
+    path) {
   ################
   # Validate loaded PMF
   if (nrow(pmf_df) != 1) {
@@ -200,6 +251,19 @@ read_interval_pmf <- function(path,
 
   pmf <- pmf_df[["value"]][[1]]
 
+  if (parameter == "right_truncation") {
+    right_trunc_date <- stringify_date(pmf_df[["reference_date"]][[1]])
+    if (rlang::is_null(right_trunc_date) || rlang::is_na(right_trunc_date)) {
+      right_trunc_date <- "NA"
+    }
+    max_ref_date <- stringify_date(report_date)
+    as_of_date <- stringify_date(as_of_date)
+    cli::cli_inform(c(
+      "Using right-truncation estimate for date {.val {right_trunc_date}}",
+      "Queried last available estimate from {.val {max_ref_date}} or earlier",
+      "Subject to parameters available as of {.val {as_of_date}}"
+    ))
+  }
   if ((length(pmf) < 1) || !rlang::is_bare_numeric(pmf)) {
     cli::cli_abort(
       c(
@@ -223,8 +287,6 @@ read_interval_pmf <- function(path,
       class = "invalid_pmf"
     )
   }
-
-  cli::cli_alert_success("{.arg {parameter}} loaded")
 
   return(pmf)
 }

--- a/man/read_disease_parameters.Rd
+++ b/man/read_disease_parameters.Rd
@@ -10,7 +10,8 @@ read_disease_parameters(
   right_truncation_path,
   disease,
   as_of_date,
-  group
+  group,
+  report_date
 )
 }
 \arguments{
@@ -25,8 +26,18 @@ date. Set for the current date for the most up-to-to date version of the
 parameters and set to an earlier date to use parameters from an earlier
 time period.}
 
-\item{group}{Used only for parameters with a state-level estimate (i.e., only
-right-truncation). The two-letter uppercase state abbreviation.}
+\item{group}{An optional parameter to subset the query to a parameter with a
+particular two-letter state abbrevation. Right now, the only parameter with
+state-specific estimates is \code{right_truncation}.}
+
+\item{report_date}{An optional parameter to subset the query to a parameter
+on or before a particular \code{report_date}. Right now, the only parameter with
+report date-specific estimates is \code{right_truncation}. Note that this
+is similar to, but different from \code{as_of_date}. The \code{report_date} is used
+to select the particular value of a time-varying estimate. This estimate
+may itself be regenerated over time (e.g., as new data becomes available or
+with a methodological update). We can pull the estimate for date
+\code{report_date} as generated on date \code{as_of_date}.}
 }
 \value{
 A named list with three PMFs. The list elements are named

--- a/man/read_interval_pmf.Rd
+++ b/man/read_interval_pmf.Rd
@@ -9,21 +9,34 @@ read_interval_pmf(
   disease = c("COVID-19", "Influenza", "test"),
   as_of_date,
   parameter = c("generation_interval", "delay", "right_truncation"),
-  group = NA
+  group = NA,
+  report_date = NA
 )
 }
 \arguments{
 \item{path}{A path to a local file}
 
-\item{disease}{One of "COVID-19" or "Influenza"}
+\item{disease}{One of \code{COVID-19} or \code{Influenza}}
 
-\item{as_of_date}{The parameters "as of" the date of the model run}
+\item{as_of_date}{Use the parameters that were used in production on this
+date. Set for the current date for the most up-to-to date version of the
+parameters and set to an earlier date to use parameters from an earlier
+time period.}
 
 \item{parameter}{One of "generation interval", "delay", or "right-truncation}
 
 \item{group}{An optional parameter to subset the query to a parameter with a
 particular two-letter state abbrevation. Right now, the only parameter with
-state-specific estimates is \code{right-truncation}.}
+state-specific estimates is \code{right_truncation}.}
+
+\item{report_date}{An optional parameter to subset the query to a parameter
+on or before a particular \code{report_date}. Right now, the only parameter with
+report date-specific estimates is \code{right_truncation}. Note that this
+is similar to, but different from \code{as_of_date}. The \code{report_date} is used
+to select the particular value of a time-varying estimate. This estimate
+may itself be regenerated over time (e.g., as new data becomes available or
+with a methodological update). We can pull the estimate for date
+\code{report_date} as generated on date \code{as_of_date}.}
 }
 \value{
 A PMF vector

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -1,0 +1,10 @@
+# NULL `reference_date` prints in output
+
+    Code
+      pmf <- check_returned_pmf(pmf_df = pmf_df, parameter = parameter, disease = disease,
+        as_of_date = as_of_date, group = group, report_date = report_date, path = path)
+    Message
+      Using right-truncation estimate for date "NA"
+      Queried last available estimate from "2023-01-15" or earlier
+      Subject to parameters available as of "2023-01-01"
+

--- a/tests/testthat/helper-write_parameter_file.R
+++ b/tests/testthat/helper-write_parameter_file.R
@@ -5,7 +5,8 @@ write_sample_parameters_file <- function(value,
                                          disease,
                                          parameter,
                                          start_date,
-                                         end_date) {
+                                         end_date,
+                                         reference_date) {
   Sys.sleep(0.05)
   df <- data.frame(
     start_date = as.Date(start_date),
@@ -13,7 +14,8 @@ write_sample_parameters_file <- function(value,
     disease = disease,
     parameter = parameter,
     end_date = end_date,
-    value = I(list(value))
+    value = I(list(value)),
+    reference_date = reference_date
   )
 
   con <- DBI::dbConnect(duckdb::duckdb())

--- a/tests/testthat/helper-write_parameter_file.R
+++ b/tests/testthat/helper-write_parameter_file.R
@@ -6,14 +6,15 @@ write_sample_parameters_file <- function(value,
                                          parameter,
                                          start_date,
                                          end_date,
+                                         geo_value,
                                          reference_date) {
   Sys.sleep(0.05)
   df <- data.frame(
     start_date = as.Date(start_date),
-    geo_value = state,
     disease = disease,
     parameter = parameter,
     end_date = end_date,
+    geo_value = geo_value,
     value = I(list(value)),
     reference_date = reference_date
   )

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -3,6 +3,7 @@ test_that("Can read all params on happy path", {
   start_date <- as.Date("2023-01-01")
   reference_date <- as.Date("2022-12-01")
   disease <- "COVID-19"
+  group <- "test_geo"
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -10,9 +11,9 @@ test_that("Can read all params on happy path", {
       parameter = "generation_interval",
       path = "generation_interval.parquet",
       disease = disease,
-      state = NA,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = NA
     )
     write_sample_parameters_file(
@@ -20,9 +21,9 @@ test_that("Can read all params on happy path", {
       parameter = "delay",
       path = "delay_interval.parquet",
       disease = disease,
-      state = NA,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = NA
     )
     write_sample_parameters_file(
@@ -30,9 +31,9 @@ test_that("Can read all params on happy path", {
       parameter = "right_truncation",
       path = "right_truncation.parquet",
       disease = disease,
-      state = "test",
       start_date = start_date,
       end_date = NA,
+      geo_value = group,
       reference_date = reference_date
     )
 
@@ -43,7 +44,7 @@ test_that("Can read all params on happy path", {
       right_truncation_path = "right_truncation.parquet",
       disease = "COVID-19",
       as_of_date = start_date + 1,
-      group = "test",
+      group = group,
       report_date = reference_date
     )
   })
@@ -71,9 +72,9 @@ test_that("Can skip params on happy path", {
       parameter = "generation_interval",
       path = "generation_interval.parquet",
       disease = disease,
-      state = NA,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = NA
     )
     write_sample_parameters_file(
@@ -81,9 +82,9 @@ test_that("Can skip params on happy path", {
       parameter = "delay",
       path = "delay_interval.parquet",
       disease = disease,
-      state = NA,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = NA
     )
     write_sample_parameters_file(
@@ -91,9 +92,9 @@ test_that("Can skip params on happy path", {
       parameter = "right_truncation",
       path = "right_truncation.parquet",
       disease = disease,
-      state = "test",
       start_date = start_date,
       end_date = NA,
+      geo_value = "test_geo",
       reference_date = reference_date
     )
 
@@ -132,11 +133,11 @@ test_that("Can read right-truncation on happy path", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = "test",
       reference_date = reference_date
     )
     actual <- read_interval_pmf(
@@ -157,12 +158,12 @@ test_that("Can read right-truncation on happy path", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = "test",
       reference_date = reference_date
     )
     actual <- read_interval_pmf(
@@ -171,6 +172,38 @@ test_that("Can read right-truncation on happy path", {
       disease = disease,
       as_of_date = start_date + 1,
       group = "test",
+      report_date = reference_date
+    )
+  })
+  expect_equal(actual, expected)
+})
+
+test_that("Can read right-truncation with no geo_value", {
+  expected <- c(0.8, 0.2)
+  path <- "test.parquet"
+  parameter <- "right_truncation"
+  start_date <- as.Date("2023-01-01")
+  reference_date <- as.Date("2022-12-01")
+
+  # COVID-19
+  disease <- "COVID-19"
+  withr::with_tempdir({
+    write_sample_parameters_file(
+      value = expected,
+      path = path,
+      disease = disease,
+      parameter = parameter,
+      start_date = start_date,
+      end_date = NA,
+      geo_value = NA,
+      reference_date = reference_date
+    )
+    actual <- read_interval_pmf(
+      path = path,
+      parameter = parameter,
+      disease = disease,
+      as_of_date = start_date + 1,
+      group = NA,
       report_date = reference_date
     )
   })
@@ -190,11 +223,11 @@ test_that("Invalid PMF errors", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
+      geo_value = "test",
       end_date = NA,
       reference_date = reference_date
     )
@@ -226,12 +259,12 @@ test_that("Can read delay on happy path", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = NA,
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = reference_date
     )
     actual <- read_interval_pmf(
@@ -243,19 +276,18 @@ test_that("Can read delay on happy path", {
   })
   expect_equal(actual, expected)
 
-
   # Influenza
   disease <- "Influenza"
   withr::with_tempdir({
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = NA,
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = reference_date
     )
     actual <- read_interval_pmf(
@@ -283,20 +315,21 @@ test_that("Not a PMF errors", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = NA,
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
-      reference_date <- reference_date
+      geo_value = NA,
+      reference_date = reference_date
     )
     expect_error(
       read_interval_pmf(
         path = path,
         disease = disease,
         as_of_date = start_date + 1,
-        parameter = parameter
+        parameter = parameter,
+        group = NA
       ),
       class = "not_a_pmf"
     )
@@ -315,13 +348,13 @@ test_that("Invalid disease errors", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
-      reference_date
+      geo_value = NA,
+      reference_date = reference_date
     )
 
     expect_error(
@@ -348,12 +381,12 @@ test_that("Invalid parameter errors", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = reference_date
     )
 
@@ -381,12 +414,12 @@ test_that("Return isn't exactly one errors", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = "test",
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = reference_date
     )
 
@@ -433,12 +466,12 @@ test_that("Invalid query throws wrapped error", {
     write_sample_parameters_file(
       value = expected,
       path = path,
-      state = NA,
       disease = disease,
       parameter = parameter,
       param = parameter,
       start_date = start_date,
       end_date = NA,
+      geo_value = NA,
       reference_date = reference_date
     )
 

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -1,6 +1,7 @@
 test_that("Can read all params on happy path", {
   expected <- c(0.8, 0.2)
   start_date <- as.Date("2023-01-01")
+  reference_date <- as.Date("2022-12-01")
   disease <- "COVID-19"
 
   withr::with_tempdir({
@@ -11,7 +12,8 @@ test_that("Can read all params on happy path", {
       disease = disease,
       state = NA,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = NA
     )
     write_sample_parameters_file(
       value = expected,
@@ -20,7 +22,8 @@ test_that("Can read all params on happy path", {
       disease = disease,
       state = NA,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = NA
     )
     write_sample_parameters_file(
       value = expected,
@@ -29,7 +32,8 @@ test_that("Can read all params on happy path", {
       disease = disease,
       state = "test",
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
 
 
@@ -39,7 +43,8 @@ test_that("Can read all params on happy path", {
       right_truncation_path = "right_truncation.parquet",
       disease = "COVID-19",
       as_of_date = start_date + 1,
-      group = "test"
+      group = "test",
+      report_date = reference_date
     )
   })
 
@@ -58,6 +63,7 @@ test_that("Can skip params on happy path", {
   expected <- c(0.8, 0.2)
   start_date <- as.Date("2023-01-01")
   disease <- "COVID-19"
+  reference_date <- as.Date("2022-12-01")
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -67,7 +73,8 @@ test_that("Can skip params on happy path", {
       disease = disease,
       state = NA,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = NA
     )
     write_sample_parameters_file(
       value = expected,
@@ -76,7 +83,8 @@ test_that("Can skip params on happy path", {
       disease = disease,
       state = NA,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = NA
     )
     write_sample_parameters_file(
       value = expected,
@@ -85,7 +93,8 @@ test_that("Can skip params on happy path", {
       disease = disease,
       state = "test",
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
 
 
@@ -115,6 +124,7 @@ test_that("Can read right-truncation on happy path", {
   path <- "test.parquet"
   parameter <- "right_truncation"
   start_date <- as.Date("2023-01-01")
+  reference_date <- as.Date("2022-12-01")
 
   # COVID-19
   disease <- "COVID-19"
@@ -126,14 +136,16 @@ test_that("Can read right-truncation on happy path", {
       disease = disease,
       parameter = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
     actual <- read_interval_pmf(
       path = path,
       parameter = parameter,
       disease = disease,
       as_of_date = start_date + 1,
-      group = "test"
+      group = "test",
+      report_date = reference_date
     )
   })
   expect_equal(actual, expected)
@@ -150,14 +162,16 @@ test_that("Can read right-truncation on happy path", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
     actual <- read_interval_pmf(
       path = path,
       parameter = parameter,
       disease = disease,
       as_of_date = start_date + 1,
-      group = "test"
+      group = "test",
+      report_date = reference_date
     )
   })
   expect_equal(actual, expected)
@@ -168,6 +182,7 @@ test_that("Invalid PMF errors", {
   path <- "test.parquet"
   parameter <- "right_truncation"
   start_date <- as.Date("2023-01-01")
+  reference_date <- as.Date("2022-12-01")
 
   # COVID-19
   disease <- "COVID-19"
@@ -180,7 +195,8 @@ test_that("Invalid PMF errors", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
     expect_error(
       read_interval_pmf(
@@ -188,7 +204,8 @@ test_that("Invalid PMF errors", {
         parameter = parameter,
         disease = disease,
         as_of_date = start_date + 1,
-        group = "test"
+        group = "test",
+        report_date = reference_date
       ),
       class = "invalid_pmf"
     )
@@ -201,6 +218,7 @@ test_that("Can read delay on happy path", {
   path <- "test.parquet"
   parameter <- "delay"
   start_date <- as.Date("2023-01-01")
+  reference_date <- NA
 
   # COVID-19
   disease <- "COVID-19"
@@ -213,7 +231,8 @@ test_that("Can read delay on happy path", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
     actual <- read_interval_pmf(
       path = path,
@@ -236,13 +255,15 @@ test_that("Can read delay on happy path", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
     actual <- read_interval_pmf(
       path = path,
       disease = disease,
       as_of_date = start_date + 1,
-      parameter = parameter
+      parameter = parameter,
+      report_date = reference_date
     )
   })
   expect_equal(actual, expected)
@@ -254,6 +275,7 @@ test_that("Not a PMF errors", {
   path <- "test.parquet"
   parameter <- "delay"
   start_date <- as.Date("2023-01-01")
+  reference_date <- NA
 
   # COVID-19
   disease <- "COVID-19"
@@ -266,7 +288,8 @@ test_that("Not a PMF errors", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date <- reference_date
     )
     expect_error(
       read_interval_pmf(
@@ -286,6 +309,7 @@ test_that("Invalid disease errors", {
   parameter <- "delay"
   start_date <- as.Date("2023-01-01")
   disease <- "not_a_valid_disease"
+  reference_date <- NA
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -296,7 +320,8 @@ test_that("Invalid disease errors", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date
     )
 
     expect_error(
@@ -317,6 +342,7 @@ test_that("Invalid parameter errors", {
   parameter <- "not_a_valid_parameter"
   start_date <- as.Date("2023-01-01")
   disease <- "COVID-19"
+  reference_date <- NA
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -327,7 +353,8 @@ test_that("Invalid parameter errors", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
 
     expect_error(
@@ -348,6 +375,7 @@ test_that("Return isn't exactly one errors", {
   parameter <- "delay"
   start_date <- as.Date("2023-01-01")
   disease <- "COVID-19"
+  reference_date <- NA
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -358,7 +386,8 @@ test_that("Return isn't exactly one errors", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
 
     # Date too early
@@ -398,6 +427,7 @@ test_that("Invalid query throws wrapped error", {
   parameter <- "delay"
   start_date <- as.Date("2023-01-01")
   disease <- "COVID-19"
+  reference_date <- NA
 
   withr::with_tempdir({
     write_sample_parameters_file(
@@ -408,7 +438,8 @@ test_that("Invalid query throws wrapped error", {
       parameter = parameter,
       param = parameter,
       start_date = start_date,
-      end_date = NA
+      end_date = NA,
+      reference_date = reference_date
     )
 
     expect_error(
@@ -421,4 +452,30 @@ test_that("Invalid query throws wrapped error", {
       class = "wrapped_error"
     )
   })
+})
+
+test_that("NULL `reference_date` prints in output", {
+  pmf_df <- data.frame(
+    value = I(list(c(0.8, 0.1, 0.1))),
+    reference_date = NA
+  )
+  parameter <- "right_truncation"
+  disease <- "test_disease"
+  as_of_date <- as.Date("2023-01-01")
+  group <- "test_group"
+  report_date <- as.Date("2023-01-15")
+  path <- "test/path/to/file.ext"
+
+  expect_snapshot(
+    pmf <- check_returned_pmf(
+      pmf_df = pmf_df,
+      parameter = parameter,
+      disease = disease,
+      as_of_date = as_of_date,
+      group = group,
+      report_date = report_date,
+      path = path
+    )
+  )
+  expect_equal(pmf, pmf_df[["value"]][[1]])
 })


### PR DESCRIPTION
Update reader to expect a reference date column. This change was a bit
finicky because we want to ignore the column when reading a GI or delay
and use the column when reading right-truncation.

I excuted this logic with an additional if block, but it tripped the
cyclocomp linter. I thought about it a bit, but still think this is the
cleanest approach (as opposed to breaking out the right-truncation
reader as its own special case or doing a post-read pre-check filter).
So I moved the checking into its own helper and left the dedicated
reader logic in the main function.

I also added some additional CLI info text on what the right-truncation
filter is looking for and what was selected. I think it's helpful, but
open to feedback that it's too much.

Closes #70
