### PR TITLE
Update key `iter_samples` to `iter_sampling`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,12 @@ push:
 
 run:
 	$(CNTR_PROG) run -it --rm -v $(PWD):/mnt $(IMAGE_NAME)
+
+test:
+	Rscript -e "testthat::test_local()"
+
+document:
+	Rscript -e "roxygen2::roxygenize()"
+
+check:
+	Rscript -e "rcmdcheck::rcmdcheck()"

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,3 +21,4 @@
 * Fix bugs in date casting caused by DuckDB v1.1.1 release
 * Drop unused pre-commit hooks
 * Write outputs to file
+* Specify number of samples draws with `iter_sampling`

--- a/R/fit_model.R
+++ b/R/fit_model.R
@@ -53,7 +53,7 @@ fit_model <- function(
     # and below as the R PRNG seed for EpiNow2 initialization
     seed = seed,
     warmup = sampler_opts[["iter_warmup"]],
-    samples = sampler_opts[["iter_samples"]],
+    samples = sampler_opts[["iter_sampling"]],
     control = list(
       adapt_delta = sampler_opts[["adapt_delta"]],
       max_treedepth = sampler_opts[["max_treedepth"]]

--- a/tests/testthat/test-fit_model.R
+++ b/tests/testthat/test-fit_model.R
@@ -39,7 +39,7 @@ test_that("Minimal model fit all params runs", {
     adapt_delta = 0.8,
     max_treedepth = 10,
     iter_warmup = 100,
-    iter_samples = 100
+    iter_sampling = 100
   )
 
   fit <- fit_model(
@@ -95,7 +95,7 @@ test_that("Minimal model fit with no right trunc or delay runs", {
     adapt_delta = 0.8,
     max_treedepth = 10,
     iter_warmup = 100,
-    iter_samples = 100
+    iter_sampling = 100
   )
 
   fit <- fit_model(
@@ -156,7 +156,7 @@ test_that("Bad params w/ failing fit issues warning and returns NA", {
     adapt_delta = 0.8,
     max_treedepth = 10,
     iter_warmup = -100,
-    iter_samples = 100
+    iter_sampling = 100
   )
 
   expect_warning(


### PR DESCRIPTION
It was already documented as `iter_sampling` in the docs, but the code
expected `iter_samples`.

`iter_sampling` follows `{cmdstanr}` syntax: https://mc-stan.org/cmdstanr/reference/model-method-sample.html

`iter_samples` is an accidental portmanteau of EpiNow2's desired
`samples` arg and `iter_sampling`.

Also added a few quality-of-life Makefile utilities

Closes #73 