### PR TITLE
Adding action to post artifact

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,6 +21,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +39,20 @@ jobs:
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+
+      - name: Save artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgdown-site
+          retention-days: 7
+
+      - name: Post to PR
+        uses: CDCgov/cfa-actions/post-artifact@v1.0.0
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          artifact-name: pkgdown-site
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and deploying the `pkgdown` site. The most important changes include adding permissions for pull requests, saving artifacts, and posting artifacts to pull requests.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/pkgdown.yaml`](diffhunk://#diff-eb3d51fe47cf000aab65c6172c06d12a34ae765221529a05451295d5e9149e80R24): Added `pull-requests: write` permission to the `permissions` section.
* [`.github/workflows/pkgdown.yaml`](diffhunk://#diff-eb3d51fe47cf000aab65c6172c06d12a34ae765221529a05451295d5e9149e80R43-R56): Added steps to save the `pkgdown-site` artifact and post it to the pull request if the event is a pull request.