### PR TITLE
Make metadata easier to use.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Change formatting of metadata values to be atomic.
+* Add `blob_storage_container` as a field to the metadata.
+* Use empty string for paths when non-existant.
 * Populated the default values of the metadata to be saved.
 * Creating a Config class to make syncing configuration differences easier.
 * Add a JSON reader for the Config class.

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -215,11 +215,7 @@ execute_model_logic <- function(config, output_dir, blob_storage_container) {
   metadata <- list(
     job_id = config@job_id,
     task_id = config@task_id,
-    data_path = ifelse(
-      # is_empty checks for NULL and empty data structures
-      rlang::is_empty(config@data@path),
-      "", config@data@path
-    ),
+    data_path = empty_str_if_non_existant(config@data@path),
     model = config@model,
     disease = config@disease,
     geo_value = config@geo_value,
@@ -227,14 +223,8 @@ execute_model_logic <- function(config, output_dir, blob_storage_container) {
     production_date = config@production_date,
     max_reference_date = config@max_reference_date,
     min_reference_date = config@min_reference_date,
-    exclusions = ifelse(
-      rlang::is_empty(config@exclusions@path),
-      "", config@exclusions@path
-    ),
-    blob_storage_container = ifelse(
-      rlang::is_empty(blob_storage_container),
-      "", blob_storage_container
-    ),
+    exclusions = empty_str_if_non_existant(config@exclusions@path),
+    blob_storage_container = empty_str_if_non_existant(blob_storage_container),
     run_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z")
   )
 

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -121,7 +121,7 @@ orchestrate_pipeline <- function(config_path,
   # `pipeline_success` is set to false, which will be stored in the
   # metadata in the next PR.
   pipeline_success <- rlang::try_fetch(
-    execute_model_logic(config, output_dir),
+    execute_model_logic(config, output_dir, blob_storage_container),
     error = function(con) {
       cli::cli_warn("Pipeline run failed",
         parent = con,
@@ -152,7 +152,7 @@ orchestrate_pipeline <- function(config_path,
 #'
 #' @rdname pipeline
 #' @export
-execute_model_logic <- function(config, output_dir) {
+execute_model_logic <- function(config, output_dir, blob_storage_container) {
   cases_df <- read_data(
     data_path = config@data@path,
     disease = config@disease,
@@ -218,7 +218,7 @@ execute_model_logic <- function(config, output_dir) {
     data_path = ifelse(
       # is_empty checks for NULL and empty data structures
       rlang::is_empty(config@data@path),
-      config@data@path, ""
+      "", config@data@path
     ),
     model = config@model,
     disease = config@disease,
@@ -227,7 +227,14 @@ execute_model_logic <- function(config, output_dir) {
     production_date = config@production_date,
     max_reference_date = config@max_reference_date,
     min_reference_date = config@min_reference_date,
-    exclusions = config@exclusions@path,
+    exclusions = ifelse(
+      rlang::is_empty(config@exclusions@path),
+      "", config@exclusions@path
+    ),
+    blob_storage_container = ifelse(
+      rlang::is_empty(blob_storage_container),
+      "", blob_storage_container
+    ),
     run_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z")
   )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,3 +19,8 @@ check_file_exists <- function(data_path) {
   }
   invisible(data_path)
 }
+
+#' If `x` is null or empty, return an empty string, otherwise `x`
+empty_str_if_non_existant <- function(x) {
+  ifelse(rlang::is_empty(x), "", x)
+}

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -76,7 +76,10 @@ write_model_outputs <- function(
           model_path = model_path
         )
       )
-      jsonlite::write_json(metadata, metadata_path, pretty = TRUE)
+      jsonlite::write_json(
+        metadata, metadata_path,
+        pretty = TRUE, auto_unbox = TRUE
+      )
       cli::cli_alert_success("Wrote metadata to {.path {metadata_path}}")
     },
     error = function(cnd) {

--- a/man/pipeline.Rd
+++ b/man/pipeline.Rd
@@ -11,7 +11,7 @@ orchestrate_pipeline(
   output_dir = "/"
 )
 
-execute_model_logic(config, output_dir)
+execute_model_logic(config, output_dir, blob_storage_container)
 }
 \arguments{
 \item{config_path}{A string specifying the file path to the JSON

--- a/tests/testthat/helper-expect_pipeline_files_written.R
+++ b/tests/testthat/helper-expect_pipeline_files_written.R
@@ -39,4 +39,9 @@ expect_pipeline_files_written <- function(
   expect_true(file.exists(metadata_path))
   metadata <- jsonlite::read_json(metadata_path)
   expect_gt(length(metadata), 0)
+
+  # Check that each field passes `rlang::is_atomic()`
+  for (field in names(metadata)) {
+    expect_true(rlang::is_atomic(metadata[[field]]))
+  }
 }

--- a/tests/testthat/test-pipeline.R
+++ b/tests/testthat/test-pipeline.R
@@ -79,7 +79,8 @@ test_that("Process pipeline produces expected outputs and returns success", {
   # Act
   pipeline_success <- execute_model_logic(
     config = config,
-    output_dir = output_dir
+    output_dir = output_dir,
+    blob_storage_container = "blah"
   )
   expect_true(pipeline_success)
 
@@ -107,7 +108,8 @@ test_that("Runs on config from generator as of 2024-11-26", {
   # Act
   pipeline_success <- execute_model_logic(
     config = config,
-    output_dir = output_dir
+    output_dir = output_dir,
+    blob_storage_container = "blah"
   )
   expect_true(pipeline_success)
 


### PR DESCRIPTION
* Change formatting of metadata values to be atomic. Test that this is the case. May have to change this at some point, if we ever add non-atomic fields on purpose.
* Add `blob_storage_container` as a field to the metadata.
* Use empty string for paths when non-existant.