### PR TITLE
Workflow to close PR pool on close

### DIFF
--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -56,7 +56,7 @@ jobs:
 
         az batch account login \
           --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
-          -- name "{{ env.BATCH_ACCOUNT }}"
+          --name "{{ env.BATCH_ACCOUNT }}"
 
         az batch pool delete \
             --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \

--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -60,4 +60,5 @@ jobs:
 
         az batch pool delete \
             --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
+            # Don't prompt for user input
             --yes

--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -6,7 +6,6 @@ on:
       - closed
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types:
       - closed
-    branches:
-      - main
 
 jobs:
 
@@ -18,10 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Get commit message
-        id: commit-message
-        run: echo "message=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
 
         # From: https://stackoverflow.com/a/58035262/2097171
       - name: Extract branch name
@@ -38,11 +32,7 @@ jobs:
             echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install az CLI
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends azure-cli
-
-      - name: Login to Azure with NNH Service Principal
+      - name: Azure login
         id: azure_login_2
         uses: azure/login@v2
         with:
@@ -50,14 +40,15 @@ jobs:
           creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
 
       - name: Delete pool
-        id: delete_pool
-        run: |
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az batch account login \
+              --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
+              --name "{{ env.BATCH_ACCOUNT }}"
 
-          az batch account login \
-            --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
-            --name "{{ env.BATCH_ACCOUNT }}"
-
-          az batch pool delete \
+            az batch pool delete \
               --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
               # Don't prompt for user input
               --yes

--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -1,0 +1,63 @@
+name: Tear down Batch pool
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  delete-pool:
+    runs_on: cdc-cdcgov
+    name: Delete Batch pool
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Get commit message
+      id: commit-message
+      run: echo "message=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
+
+      # From: https://stackoverflow.com/a/58035262/2097171
+    - name: Extract branch name
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: branch-name
+
+    - name: Figure out tag (either latest if it is main or the branch name)
+      id: image-tag
+      run: |
+        if [ "${{ steps.branch-name.outputs.branch }}" = "main" ]; then
+          echo "tag=latest" >> $GITHUB_OUTPUT
+        else
+          echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Install az CLI
+      run: |
+        apt-get update && apt-get install -y --no-install-recommends azure-cli
+
+    - name: Login to Azure with NNH Service Principal
+      id: azure_login_2
+      uses: azure/login@v2
+      with:
+      # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
+        creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+
+    - name: Delete pool
+      id: delete_pool
+      run: |
+
+        az batch account login \
+          --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
+          -- name "{{ env.BATCH_ACCOUNT }}"
+
+        az batch pool delete \
+            --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
+            --yes

--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -13,51 +13,51 @@ jobs:
     runs_on: cdc-cdcgov
     name: Delete Batch pool
 
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Get commit message
-      id: commit-message
-      run: echo "message=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
+      - name: Get commit message
+        id: commit-message
+        run: echo "message=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
 
-      # From: https://stackoverflow.com/a/58035262/2097171
-    - name: Extract branch name
-      shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      id: branch-name
+        # From: https://stackoverflow.com/a/58035262/2097171
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: branch-name
 
-    - name: Figure out tag (either latest if it is main or the branch name)
-      id: image-tag
-      run: |
-        if [ "${{ steps.branch-name.outputs.branch }}" = "main" ]; then
-          echo "tag=latest" >> $GITHUB_OUTPUT
-        else
-          echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
-        fi
+      - name: Figure out tag (either latest if it is main or the branch name)
+        id: image-tag
+        run: |
+          if [ "${{ steps.branch-name.outputs.branch }}" = "main" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
+          fi
 
-    - name: Install az CLI
-      run: |
-        apt-get update && apt-get install -y --no-install-recommends azure-cli
+      - name: Install az CLI
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends azure-cli
 
-    - name: Login to Azure with NNH Service Principal
-      id: azure_login_2
-      uses: azure/login@v2
-      with:
-      # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
-        creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+      - name: Login to Azure with NNH Service Principal
+        id: azure_login_2
+        uses: azure/login@v2
+        with:
+        # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
+          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
 
-    - name: Delete pool
-      id: delete_pool
-      run: |
+      - name: Delete pool
+        id: delete_pool
+        run: |
 
-        az batch account login \
-          --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
-          --name "{{ env.BATCH_ACCOUNT }}"
+          az batch account login \
+            --resource-group {{ secrets.PRD_RESOURCE_GROUP }} \
+            --name "{{ env.BATCH_ACCOUNT }}"
 
-        az batch pool delete \
-            --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
-            # Don't prompt for user input
-            --yes
+          az batch pool delete \
+              --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
+              # Don't prompt for user input
+              --yes

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Read parameters on the same day correctly
 * Re-add missing dependency in python venv
 * Don't emit DEBUG level logs from EpiNow2
+* Clean up Azure Batch pools on PR close
 * Added function families to documentation
 * Renamed file containing diagnostic functions
 * Change formatting of metadata values to be atomic.


### PR DESCRIPTION
This workflow _should_ clean up the associated Batch pool when closing
the PR.

It doesn't clean up the associated tagged image in ACR (that's harder)
or jobs that were run on the pool. It would be nice to auto-delete any
linked jobs, but it seems tricker than I'd want? I'll plan to revisit
that when moving this into a dedicated action outside this repo.

Closes #62
