### PR TITLE
fix call to job.py from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 REGISTRY=cfaprdbatchcr.azurecr.io/
 IMAGE_NAME=cfa-epinow2-pipeline
 BRANCH=$(shell git branch --show-current)
+CONFIG_CONTAINER=rt-epinow2-config
 ifeq ($(BRANCH), 'main')
 TAG=latest
 else
@@ -37,7 +38,7 @@ run-batch:
 	docker run --rm  \
 	--env-file .env \
 	-it \
-	batch python job.py "$(IMAGE)" "$(POOL)" "$(JOB)"
+	batch python job.py "$(IMAGE)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 run:
 	docker run --mount type=bind,source=$(PWD),target=/mnt -it \


### PR DESCRIPTION
`azure/job.py` expects `config_container` to be the second argument.
https://github.com/CDCgov/cfa-epinow2-pipeline/blob/2a9798c65ef4e36a3a660987371184d0086716af/azure/job.py#L17


The makefile didn't have it yet.