### PR TITLE
Read same-day parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Read parameters on the same day correctly
 * Added function families to documentation
 * Renamed file containing diagnostic functions
 * Change formatting of metadata values to be atomic.

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -150,7 +150,7 @@ read_interval_pmf <- function(path,
     WHERE 1=1
       AND parameter = ?
       AND disease = ?
-      AND start_date < ? :: DATE
+      AND start_date <= ? :: DATE
       AND (CAST(end_date AS DATE) > ? :: DATE OR end_date IS NULL)
     "
   parameters <- list(

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -512,3 +512,35 @@ test_that("NULL `reference_date` prints in output", {
   )
   expect_equal(pmf, pmf_df[["value"]][[1]])
 })
+
+test_that("Same-day parameter can be read", {
+  expected <- c(0.8, 0.2)
+  path <- "test.parquet"
+  parameter <- "delay"
+  start_date <- as.Date("2023-01-01")
+  disease <- "COVID-19"
+  reference_date <- NA
+
+  withr::with_tempdir({
+    write_sample_parameters_file(
+      value = expected,
+      path = path,
+      disease = disease,
+      parameter = parameter,
+      param = parameter,
+      start_date = start_date,
+      end_date = NA,
+      geo_value = NA,
+      reference_date = reference_date
+    )
+
+    actual <- read_interval_pmf(
+      path = path,
+      disease = disease,
+      as_of_date = start_date,
+      parameter = parameter
+    )
+
+    expect_equal(actual, expected)
+  })
+})


### PR DESCRIPTION
Previously a same-day as-of date would have erorred as unable to match
a day, rather than correctly reading for the given start date
