### PR TITLE
Remove pool delete workflow typo

### DIFF
--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   delete-pool:
-    runs_on: cdc-cdcgov
+    runs-on: cdc-cdcgov
     name: Delete Batch pool
 
     steps:


### PR DESCRIPTION
The first run threw:

> Invalid workflow file: .github/workflows/delete-pool-on-pr-close.yaml#L11
The workflow is not valid. .github/workflows/delete-pool-on-pr-close.yaml (Line: 11, Col: 5): Unexpected value 'runs_on' .github/workflows/delete-pool-on-pr-close.yaml (Line: 11, Col: 5): Required property is missing: runs-on

See here:
https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/12773389898
