### PR TITLE
Updating config workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ endif
 
 CONFIG=test.json
 POOL="cfa-epinow2-$(TAG)"
-TIMESTAMP=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-JOB=Rt-estimation-$(TIMESTAMP)
+TIMESTAMP:=$(shell  date -u +"%Y%m%d_%H%M%S")
+JOB:=Rt-estimation-$(TIMESTAMP)
 
 deps:
 	docker build -t $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG) -f Dockerfile-dependencies
@@ -35,7 +35,7 @@ config:
 	  -f state=all \
 	  -f job_id=$(JOB)
 
-run-batch:
+run-batch: config
 	docker build -f Dockerfile-batch -t batch . --no-cache
 	docker run --rm  \
 	--env-file .env \

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,11 @@ tag:
 	docker tag $(IMAGE_NAME):$(TAG) $(REGISTRY)$(IMAGE_NAME):$(TAG)
 
 config:
-	@read -p "Enter job_id: " job_id; \
 	gh workflow run \
 	  -R cdcgov/cfa-config-generator run-workload.yaml  \
 	  -f disease=all \
 	  -f state=all \
-	  -f job_id=$$job_id
+	  -f job_id=$(JOB)
 
 run-batch:
 	docker build -f Dockerfile-batch -t batch . --no-cache

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ tag:
 	docker tag $(IMAGE_NAME):$(TAG) $(REGISTRY)$(IMAGE_NAME):$(TAG)
 
 config:
+	@read -p "Enter job_id: " job_id; \
 	gh workflow run \
 	  -R cdcgov/cfa-config-generator run-workload.yaml  \
 	  -f disease=all \
-	  -f state=all
+	  -f state=all \
+	  -f job_id=$$job_id
 
 run-batch:
 	docker build -f Dockerfile-batch -t batch . --no-cache

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ endif
 
 CONFIG=test.json
 POOL="cfa-epinow2-$(TAG)"
-JOB=$(POOL)
+TIMESTAMP=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+JOB=Rt-estimation-$(TIMESTAMP)
 
 deps:
 	docker build -t $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG) -f Dockerfile-dependencies

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Add functionality to pass `job_id` to config generation
 * Build Batch pool on merge to main
 * Install suggests into base first-step image
 * Fixed issue with running `make pull` while on main.

--- a/azure/job.py
+++ b/azure/job.py
@@ -36,8 +36,9 @@ if __name__ == "__main__":
 
     #############
     # Set up job
+    batch_job_id = f"batch-{job_id}"
     job = batchmodels.JobAddParameter(
-        id=job_id,
+        id=batch_job_id,
         pool_info=batchmodels.PoolInformation(pool_id=pool_id)
     )
 

--- a/azure/job.py
+++ b/azure/job.py
@@ -51,11 +51,10 @@ if __name__ == "__main__":
     # Get tasks
     blob_service_client = BlobServiceClient(blob_url, credential_v2)
     container_client = blob_service_client.get_container_client(container=config_container)
-    two_mins_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=2)
     task_configs: list[str] = [
         b.name
         for b in container_client.list_blobs()
-        if b.creation_time > two_mins_ago
+        if job_id in b.name
     ]
     if len(task_configs) == 0:
         raise ValueError("No tasks found")


### PR DESCRIPTION
Closes #142 --

Allows the user to provide a job_id to the config generation in `Makefile`. Filters tasks in `azure/job.py` by the job_id instead of time created.

I still need to test this in Batch -- my understanding is this PR will spin up a new pool. Do I just need to run `make run-batch` to test this? @zsusswein @natemcintosh 

