### PR TITLE
Don't prompt for input (add `--yes`)

### DIFF
--- a/.github/workflows/delete-pool-on-pr-close.yaml
+++ b/.github/workflows/delete-pool-on-pr-close.yaml
@@ -46,9 +46,9 @@ jobs:
           inlineScript: |
             az batch account login \
               --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
-              --name "${{ secrets.BATCH_ACCOUNT }}"
+              --name "${{ secrets.BATCH_ACCOUNT }}" \
+              --yes
 
             az batch pool delete \
               --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
-              # Don't prompt for user input
               --yes


### PR DESCRIPTION
Latest error is
> Starting script execution via docker image mcr.microsoft.com/azure-cli:latest
WARNING: Unable to load extension 'azure-batch-cli-extensions: No module named 'distutils''. Use --debug for more information.
WARNING: Unable to prompt for confirmation as no tty available. Use --yes.
ERROR: Operation cancelled.
Error: Error: az cli script failed.
cleaning up container...
