### PR TITLE
Drop test prefix

### DIFF
--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -125,7 +125,7 @@ jobs:
           push: true # This can be toggled manually for tweaking.
           no-cache: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-${{ needs.build-dependencies-image.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-dependencies-image.outputs.tag }}
           file: ./Dockerfile
           build-args: |
             TAG=${{ needs.build-dependencies-image.outputs.tag }}
@@ -169,7 +169,7 @@ jobs:
           EOF
 
           # Replacing placeholders in the config file
-          sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
+          sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
           sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
           sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ TAG=$(BRANCH)
 endif
 
 CONFIG=test.json
-JOB=batch-test
-
+POOL="cfa-epinow2-$(TAG)"
+JOB=$(POOL)
 
 deps:
 	docker build -t $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG) -f Dockerfile-dependencies
@@ -38,7 +38,7 @@ run-batch:
 	docker run --rm  \
 	--env-file .env \
 	-it \
-	batch python job.py "$(IMAGE)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 run:
 	docker run --mount type=bind,source=$(PWD),target=/mnt -it \

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ deps:
 pull:
 	az acr login --name 'cfaprdbatchcr'
 	docker pull $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG)
-	docker pull $(REGISTRY)$(IMAGE_NAME):test-$(TAG)
+	docker pull $(REGISTRY)$(IMAGE_NAME):$(TAG)
 
 build:
-	docker build -t $(REGISTRY)$(IMAGE_NAME):test-$(TAG) \
+	docker build -t $(REGISTRY)$(IMAGE_NAME):$(TAG) \
 		--build-arg TAG=$(TAG) -f Dockerfile .
 
 tag:
@@ -43,14 +43,14 @@ run-batch:
 run:
 	docker run --mount type=bind,source=$(PWD),target=/mnt -it \
 	--env-file .env \
-	--rm $(REGISTRY)$(IMAGE_NAME):test-$(TAG) \
+	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
 	Rscript -e "CFAEpiNow2Pipeline::orchestrate_pipeline('$(CONFIG)', config_container = 'rt-epinow2-config', input_dir = '/mnt/input', output_dir = '/mnt', output_container = 'zs-test-pipeline-update')"
 
 
 up:
 	docker run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
 	--env-file .env \
-	--rm $(REGISTRY)$(IMAGE_NAME):test-$(TAG) /bin/bash
+	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) /bin/bash
 
 run-function:
 	docker run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
+
+* Fix Batch run trigger from Makefile and drop `test-` prefix
 * Add fit observation data to summaries
 * Use a consistent name scheme for geographies: `geo_value`
 * Created workflow_dispatch docker system prune -a -f action; made container job ignore irrelevant changes

--- a/azure/job.py
+++ b/azure/job.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     # Set up task on job
     registry = os.environ["AZURE_CONTAINER_REGISTRY"]
     task_container_settings = batchmodels.TaskContainerSettings(
-        image_name=registry + '/cfa-epinow2-pipeline:test-' + image_name,
+        image_name=registry + '/cfa-epinow2-pipeline:' + image_name,
         container_run_options='--rm --workdir /'
     )
     task_env_settings = [

--- a/azure/job.py
+++ b/azure/job.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import datetime
 import sys
 import os
@@ -63,10 +65,10 @@ if __name__ == "__main__":
         print(f"Creating {len(task_configs)} tasks in job {job_id} on pool {pool_id}")
 
     ###########
-    # Set up task on job
+    # Set up tasks on job
     registry = os.environ["AZURE_CONTAINER_REGISTRY"]
     task_container_settings = batchmodels.TaskContainerSettings(
-        image_name=registry + '/cfa-epinow2-pipeline:' + image_name,
+        image_name=image_name,
         container_run_options='--rm --workdir /'
     )
     task_env_settings = [


### PR DESCRIPTION
This PR drops the `test-` prefix so that everything is strictly named based off of the branch. It also updates the job & task deployment to use the new naming scheme and make the process more transparent.

The updates to the `azure/job.py` make it easier to kick off a job via GHA but it doesn't actually implement this step. Instead it's left as an update in the Makefile. I've made a new issue, #164 to track the GHA deployment but don't assign it a priority because I'm not sure it's imminently needed -- it'll be worth re-assessing if it would be helpful as we start running this pipeline more.

Closes #87 

I'm also going to say this closes #48. The job setup is now handled as needed by this script.

I ran this PR over a couple of vintages in Batch. Everything ran successfully but note that this code won't work by default on the other branches at first because they'll still rely on the `test-` prefix. We can get around that by manually specifying the prefix as Agastya does in his test in #151.