### PR TITLE
Delete jobs with pools

### DIFF
--- a/.github/scripts/cleanup-on-pr-close.sh
+++ b/.github/scripts/cleanup-on-pr-close.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Delete Batch Pools and associated jobs
+
+if [ "${#}" -ne 3 ]; then
+  echo "Usage: $0 <account_name> <resource_group> <pool_id>"
+  exit 1
+fi
+
+ACCOUNT_NAME="$1"
+RESOURCE_GROUP="$2"
+POOL_ID="$3"
+
+echo "Logging into Batch account"
+az batch account login \
+  --name "${ACCOUNT_NAME}" \
+  --resource-group "${RESOURCE_GROUP}"
+
+##########################
+# Fetch & delete jobs
+
+echo "Fetching jobs in pool ${POOL_ID}"
+
+JOB_IDS=$(az batch job list --query "[?poolInfo.poolId=='$POOL_ID'].id" --output tsv)
+
+if [ -z "${JOB_IDS}" ]; then
+  echo "No jobs found in pool: ${POOL_ID}"
+else
+  # Iterate line-by-line over the tsv list
+  echo "${JOB_IDS}" | while IFS= read -r JOB_ID; do
+    echo "Deleting job ${JOB_ID}"
+    az batch job delete --job-id "${JOB_ID}" --yes
+  done
+fi
+
+##########################
+# Delete pool
+
+az batch pool delete --pool-id "${POOL_ID}" --yes 2>/dev/null || {
+  echo "Pool ${POOL_ID} does not exist or has already been deleted"
+}

--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -1,6 +1,7 @@
 name: Tear down Batch pool
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -18,19 +19,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
         # From: https://stackoverflow.com/a/58035262/2097171
-      - name: Extract branch name
+      - name: Extract tag
         shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: branch-name
-
-      - name: Figure out tag (either latest if it is main or the branch name)
-        id: image-tag
-        run: |
-          if [ "${{ steps.branch-name.outputs.branch }}" = "main" ]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Azure login
         id: azure_login_2
@@ -44,10 +36,8 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az batch account login \
-              --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
-              --name "${{ secrets.BATCH_ACCOUNT }}"
-
-            az batch pool delete \
-              --pool-id "cfa-epinow2-${{ steps.image-tag.outputs.tag }}" \
-              --yes
+            chmod +x $GITHUB_WORKSPACE/.github/scripts/cleanup-on-pr-close.sh
+            $GITHUB_WORKSPACE/.github/scripts/cleanup-on-pr-close.sh \
+              "${{ secrets.BATCH_ACCOUNT }}" \
+              "${{ secrets.PRD_RESOURCE_GROUP }}" \
+              "cfa-epinow2-${{ steps.brach-name.outputs.tag }}"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CFAEpiNow2Pipeline (development version)
 
+* Refactor cleanup action to also delete jobs
 * Fix Batch run trigger from Makefile and drop `test-` prefix
 * Add fit observation data to summaries
 * Use a consistent name scheme for geographies: `geo_value`


### PR DESCRIPTION
And move complete logic into a new shell script to support local runs.
This change cleans up the logic quite a bit.

Also drop the stuff to support running on main because of the PR dependence
that goes with the cleanup action.
