### PR TITLE
Clean up Batch job launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ config:
 	  -f job_id=$(JOB)
 
 run-batch: config
+	@echo "Hanging for 15 seconds to wait for configs to generate"
+	sleep 15
 	docker build -f Dockerfile-batch -t batch . --no-cache
 	docker run --rm  \
 	--env-file .env \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 CONFIG=test.json
 POOL="cfa-epinow2-$(TAG)"
 TIMESTAMP:=$(shell  date -u +"%Y%m%d_%H%M%S")
-JOB:=Rt-estimation-$(TIMESTAMP)
+JOB:=$(POOL)
 
 deps:
 	docker build -t $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG) -f Dockerfile-dependencies

--- a/azure/job.py
+++ b/azure/job.py
@@ -95,4 +95,4 @@ if __name__ == "__main__":
             user_identity=user_identity
         )
 
-        batch_client.task.add(job_id, task)
+        batch_client.task.add(batch_job_id, task)


### PR DESCRIPTION
Some follow-up to #151.

Fixes the timing to wait for the configs to make it to Blob and
cleans up the Batch job name.
