### PR TITLE
Unique job_id and fixed batch_job_id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 CONFIG=test.json
 POOL="cfa-epinow2-$(TAG)"
 TIMESTAMP:=$(shell  date -u +"%Y%m%d_%H%M%S")
-JOB:=$(POOL)
+JOB:=Rt-estimation-$(TIMESTAMP)
 
 deps:
 	$(CNTR_MGR) build -t $(REGISTRY)$(IMAGE_NAME)-dependencies:$(TAG) -f Dockerfile-dependencies

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Allows unique job_ids for runs.
 * Makefile supports either docker or podman as arguments to setup & manage containers
 
 # CFAEpiNow2Pipeline v0.1.0

--- a/azure/job.py
+++ b/azure/job.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     #############
     # Set up job
-    batch_job_id = f"batch-{job_id}"
+    batch_job_id = pool_id
     job = batchmodels.JobAddParameter(
         id=batch_job_id,
         pool_info=batchmodels.PoolInformation(pool_id=pool_id)


### PR DESCRIPTION
Closes #176 --

Creates a timestamp based `job_id` that gets passed to the config generator, only those job_ids are pulled in `job.py`. We also fix the batch job name to the pool name, so any tasks get appended to those (instead of creating a new one each run).

Tested in Batch by running
`make run-batch` in pool `cfa-epinow2-am-unique-job-id`