### PR TITLE
Azure Container App Runner

### DIFF
--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -80,6 +80,7 @@ jobs:
         run: |
           executor \
             --context $(pwd) \
+            --build-arg "TAG=latest" \
             --no-push
 
   # build-pipeline-image:

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -53,7 +53,6 @@ jobs:
 
   build-dependencies-image:
     needs: check-dependencies-changed
-    if: needs.check-dependencies-changed.outputs.description == 'true'
     runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 
@@ -95,11 +94,15 @@ jobs:
       - name: Build and push
         shell: bash -ie {0}
         run: |
-          kaniko \
-            --context $(pwd) \
-            --dockerfile "Dockerfile-dependencies" \
-            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}" \
-            --no-push
+          if [ "${{ needs.check-dependencies-changed.outputs.description }}" = "true" ]; then
+            kaniko \
+              --context $(pwd) \
+              --dockerfile "Dockerfile-dependencies" \
+              --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}" \
+              --no-push
+          else
+            echo "Skipping build and push since dependencies haven't changed"
+          fi
 
   build-pipeline-image:
 
@@ -125,7 +128,7 @@ jobs:
       - name: Build and push model pipeline image for Azure batch
         id: build_and_push_model_image
         run: |
-          if [ "${{ needs.check-dependencies-changed.outputs.description }}" == "true" ]; then
+          if [ "${{ needs.check-dependencies-changed.outputs.description }}" = "true" ]; then
             echo "Dependencies changed, using branch tag"
             DEPENDENCY_TAG="${{ steps.image-tag.outputs.tag }}"
           else

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        shell: bash -ie pipefail {0}
+        shell: bash -ie
         run: |
           executor \
             --context $(pwd) \

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -37,27 +37,13 @@ env:
 
 jobs:
 
-  check-dependencies-changed:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Filter modified files
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            description:
-              - 'DESCRIPTION'
-
   build-dependencies-image:
-    needs: check-dependencies-changed
     runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 
     outputs:
       tag: ${{ steps.image-tag.outputs.tag }}
+      did-dependencies-change: ${{ steps.filter.outputs.description }}
 
     steps:
 
@@ -84,6 +70,14 @@ jobs:
             echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Filter modified files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            description:
+              - 'DESCRIPTION'
+
       - name: Login to the Container Registry
         uses: docker/login-action@v3
         with:
@@ -94,7 +88,7 @@ jobs:
       - name: Build and push
         shell: bash -ie {0}
         run: |
-          if [ "${{ needs.check-dependencies-changed.outputs.description }}" = "true" ]; then
+          if [ "${{ steps.filter.outputs.description }}" = "true" ]; then
             kaniko \
               --context $(pwd) \
               --dockerfile "Dockerfile-dependencies" \
@@ -107,10 +101,7 @@ jobs:
   build-pipeline-image:
 
     name: Build pipeline image
-
-    needs: 
-      - build-dependencies-image
-      - check-dependencies-changed
+    needs: build-dependencies-image
     runs-on: cfa-cdcgov-aca
 
     outputs:
@@ -128,7 +119,7 @@ jobs:
       - name: Build and push model pipeline image for Azure batch
         id: build_and_push_model_image
         run: |
-          if [ "${{ needs.check-dependencies-changed.outputs.description }}" = "true" ]; then
+          if [ "${{ needs.build-dependencies-image.outputs.did-dependencies-change }}" = "true" ]; then
             echo "Dependencies changed, using branch tag"
             DEPENDENCY_TAG="${{ steps.image-tag.outputs.tag }}"
           else

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -36,19 +36,8 @@ env:
   IMAGE_NAME: cfa-epinow2-pipeline
 
 jobs:
-  test-python:
-    runs-on: cfa-cdcgov-aca
-    name: Test Python
-    steps:
-      # - name: Setup Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.12'
-      - name: Test Python
-        run: 'python3 --version'
 
   build-dependencies-image:
-    if: true == false
     runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -77,7 +77,6 @@ jobs:
           password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        shell: bash -ie {0}
         run: |
           executor \
             --context $(pwd) \

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -138,7 +138,7 @@ jobs:
             --context $(pwd) \
             --dockerfile "Dockerfile" \
             --build-arg "TAG=$DEPENDENCY_TAG" \
-            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" 
+            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG"
   batch-pool:
 
     name: Create Batch Pool and Submit Jobs

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -2,7 +2,6 @@ name: Create Docker Image and Azure Pool
 
 # This GitHub Actions workflow builds a Docker image for the
 # cfa-epinow2-pipeline-docker project. In-container tests can be added here.
-
 on:
   workflow_dispatch:
   pull_request:
@@ -30,6 +29,9 @@ on:
     branches:
       - main
 
+defaults:
+  run:
+    shell: bash -ie {0}
 env:
   # Together, these form: cfaprdbatchcr.azurecr.io/cfa-epinow2-pipeline
   REGISTRY: cfaprdbatchcr.azurecr.io
@@ -57,7 +59,6 @@ jobs:
 
       # From: https://stackoverflow.com/a/58035262/2097171
       - name: Extract branch name
-        shell: bash
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: branch-name
 
@@ -89,7 +90,6 @@ jobs:
 
       - name: Build and push
         # need bash -i to use aliases on runner
-        shell: bash -ie {0}
         run: |
           if [ "${{ steps.filter.outputs.dependencies }}" = "true" ]; then
             kaniko \
@@ -124,7 +124,6 @@ jobs:
       - name: Build and push model pipeline image for Azure batch
         id: build_and_push_model_image
         # need bash -i to use aliases on runner
-        shell: bash -ie {0}
         run: |
           BUILD_TAG="${{ needs.build-dependencies-image.outputs.tag }}"
           if [ "${{ needs.build-dependencies-image.outputs.did-dependencies-change }}" = "true" ]; then

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -37,7 +37,23 @@ env:
 
 jobs:
 
+  check-dependencies-changed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Filter modified files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            description:
+              - 'DESCRIPTION'
+
   build-dependencies-image:
+    needs: check-dependencies-changed
+    if: needs.check-dependencies-changed.outputs.description == 'true'
     runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 
@@ -81,34 +97,46 @@ jobs:
         run: |
           kaniko \
             --context $(pwd) \
-            --build-arg "TAG=latest" \
+            --dockerfile "Dockerfile-dependencies" \
+            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}" \
             --no-push
 
-  # build-pipeline-image:
-  #
-  #   name: Build pipeline image
-  #
-  #   needs: build-dependencies-image
-  #   runs-on: cfa-cdcgov-aca
-  #
-  #   outputs:
-  #     tag: ${{ needs.build-dependencies-image.outputs.tag }}
-  #
-  #   steps:
-  #
-  #     # - name: Login to the Container Registry
-  #     #   uses: docker/login-action@v3
-  #     #   with:
-  #     #     registry: "cfaprdbatchcr.azurecr.io"
-  #     #     username: "cfaprdbatchcr"
-  #     #     password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
-  #
-  #     - name: Build and push model pipeline image for Azure batch
-  #       id: build_and_push_model_image
-  #       run: |
-  #         executor \
-  #           --context $(pwd) \
-  #           --no-push
+  build-pipeline-image:
+
+    name: Build pipeline image
+
+    needs: 
+      - build-dependencies-image
+      - check-dependencies-changed
+    runs-on: cfa-cdcgov-aca
+
+    outputs:
+      tag: ${{ needs.build-dependencies-image.outputs.tag }}
+
+    steps:
+
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: "cfaprdbatchcr.azurecr.io"
+          username: "cfaprdbatchcr"
+          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+
+      - name: Build and push model pipeline image for Azure batch
+        id: build_and_push_model_image
+        run: |
+          if [ "${{ needs.check-dependencies-changed.outputs.description }}" == "true" ]; then
+            echo "Dependencies changed, using branch tag"
+            DEPENDENCY_TAG="${{ steps.image-tag.outputs.tag }}"
+          else
+            echo "No deependencies changed, using tag: latest"
+            TAG="latest"
+          fi
+          kaniko \
+            --context $(pwd) \
+            --build-arg "TAG=$DEPENDENCY_TAG" \
+            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}" \
+            --no-push
         #
         #
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -36,8 +36,18 @@ env:
   IMAGE_NAME: cfa-epinow2-pipeline
 
 jobs:
+  test-python:
+    runs-on: cfa-cdcgov-aca
+    name: Test Python
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+        run: 'python3 --version'
 
   build-dependencies-image:
+    if: true == false
     runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 
@@ -137,99 +147,98 @@ jobs:
             --dockerfile "Dockerfile" \
             --build-arg "TAG=$DEPENDENCY_TAG" \
             --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
-        #
-        #
-        #
-        #
-  # batch-pool:
+  batch-pool:
 
-  #   name: Create Batch Pool and Submit Jobs
-  #   runs-on: cfa-cdcgov-aca
-  #   needs: build-pipeline-image
-  #   container: python:3.12
+    name: Create Batch Pool and Submit Jobs
+    runs-on: cfa-cdcgov-aca
+    needs: build-pipeline-image
 
-  #   permissions:
-  #     contents: read
-  #     packages: write
+    permissions:
+      contents: read
+      packages: write
 
-  #   env:
-  #     TAG: ${{ needs.build-pipeline-image.outputs.tag }}
-  #     # Every Azure Batch Pool parameter can simply go here,
-  #     # no python module or config toml necessary
-  #     POOL_ID: "cfa-epinow2-${{ needs.build-pipeline-image.outputs.tag }}"
-  #     BATCH_ACCOUNT:     "cfaprdba"
-  #     BATCH_ENDPOINT:    "https://cfaprdba.eastus.batch.azure.com/"
-  #     VM_IMAGE_TAG:      "canonical:0001-com-ubuntu-server-focal:20_04-lts"
-  #     NODE_AGENT_SKU_ID: "batch.node.ubuntu 20.04"
-  #     VM_SIZE:           "standard_a4m_v2"
-  #     RESOURCE_GROUP:    ${{ secrets.PRD_RESOURCE_GROUP }}
+    env:
+      TAG: ${{ needs.build-pipeline-image.outputs.tag }}
+      # Every Azure Batch Pool parameter can simply go here,
+      # no python module or config toml necessary
+      POOL_ID: "cfa-epinow2-${{ needs.build-pipeline-image.outputs.tag }}"
+      BATCH_ACCOUNT:     "cfaprdba"
+      BATCH_ENDPOINT:    "https://cfaprdba.eastus.batch.azure.com/"
+      VM_IMAGE_TAG:      "canonical:0001-com-ubuntu-server-focal:20_04-lts"
+      NODE_AGENT_SKU_ID: "batch.node.ubuntu 20.04"
+      VM_SIZE:           "standard_a4m_v2"
+      RESOURCE_GROUP:    ${{ secrets.PRD_RESOURCE_GROUP }}
 
-  #   steps:
-  #     - name: Checkout Repo
-  #       id: checkout_repo
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Checkout Repo
+        id: checkout_repo
+        uses: actions/checkout@v4
 
-  #     # This step is only needed during the action to write the
-  #     # config file. Users can have a config file stored in their VAP
-  #     # sessions. In the future, we will have the config.toml file
-  #     # distributed with the repo (encrypted).
-  #     - name: Writing out config file
-  #       run: |
-  #         cat <<EOF > pool-config-${{ github.sha }}.toml
-  #         ${{ secrets.POOL_CONFIG_TOML }}
-  #         EOF
+      # This step is only needed during the action to write the
+      # config file. Users can have a config file stored in their VAP
+      # sessions. In the future, we will have the config.toml file
+      # distributed with the repo (encrypted).
+      - name: Writing out config file
+        run: |
+          cat <<EOF > pool-config-${{ github.sha }}.toml
+          ${{ secrets.POOL_CONFIG_TOML }}
+          EOF
 
-  #         # Replacing placeholders in the config file
-  #         sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
-  #         sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
-  #         sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
+          # Replacing placeholders in the config file
+          sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
+          sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
+          sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
 
-  #     - name: Ensuring the Azure CLI is installed
-  #       run: |
-  #         apt-get update && apt-get install -y --no-install-recommends azure-cli
+      - name: Ensuring the Azure CLI is installed
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends azure-cli
 
-  #     - name: Login to Azure with NNH Service Principal
-  #       id: azure_login_2
-  #       uses: azure/login@v2
-  #       with:
-  #       # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
-  #         creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+      - name: Login to Azure with NNH Service Principal
+        id: azure_login_2
+        uses: azure/login@v2
+        with:
+        # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
+          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
 
-  #     #########################################################################
-  #     # Checking if the pool exists
-  #     # This is done via az batch pool list. If there is no pool matching the
-  #     # pool id (which is a function of the tag, i.e., branch name), then we
-  #     # pool-exists will be ''.
-  #     #########################################################################
-  #     - name: Check if pool exists
-  #       id: check_pool_id
-  #       run: |
+      #########################################################################
+      # Checking if the pool exists
+      # This is done via az batch pool list. If there is no pool matching the
+      # pool id (which is a function of the tag, i.e., branch name), then we
+      # pool-exists will be ''.
+      #########################################################################
+      - name: Check if pool exists
+        id: check_pool_id
+        run: |
 
-  #         az batch account login \
-  #           --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
-  #           --name "${{ env.BATCH_ACCOUNT }}"
+          az batch account login \
+            --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
+            --name "${{ env.BATCH_ACCOUNT }}"
 
-  #         az batch pool list \
-  #           --output tsv \
-  #           --filter "(id eq '${{ env.POOL_ID }}')" \
-  #           --query "[].[id, allocationState, creationTime]" > \
-  #           pool-list-${{ github.sha }}
+          az batch pool list \
+            --output tsv \
+            --filter "(id eq '${{ env.POOL_ID }}')" \
+            --query "[].[id, allocationState, creationTime]" > \
+            pool-list-${{ github.sha }}
 
-  #         echo "pool-exists=$(cat pool-list-${{ github.sha }})" >> \
-  #           $GITHUB_OUTPUT
+          echo "pool-exists=$(cat pool-list-${{ github.sha }})" >> \
+            $GITHUB_OUTPUT
 
-  #     - name: Create cfa-epinow2-pipeline Pool
-  #       id: create_batch_pool
+      - name: Create cfa-epinow2-pipeline Pool
+        id: create_batch_pool
 
-  #       # This is a conditional step that will only run if the pool does not
-  #       # exist
-  #       if: ${{ steps.check_pool_id.outputs.pool-exists == '' }}
+        # This is a conditional step that will only run if the pool does not
+        # exist
+        if: ${{ steps.check_pool_id.outputs.pool-exists == '' }}
 
-  #       # The call to the az cli that actually generates the pool
-  #       run: |
-  #         # Running the python script azure/pool.py passing the config file
-  #         # as an argument
-  #         pip install -r azure/requirements.txt
-  #         python3 azure/pool.py \
-  #           pool-config-${{ github.sha }}.toml \
-  #           batch-autoscale-formula.txt
+        # The call to the az cli that actually generates the pool
+        run: |
+          # Running the python script azure/pool.py passing the config file
+          # as an argument
+          pip install -r azure/requirements.txt
+          python3 azure/pool.py \
+            pool-config-${{ github.sha }}.toml \
+            batch-autoscale-formula.txt

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -43,7 +43,7 @@ jobs:
 
     outputs:
       tag: ${{ steps.image-tag.outputs.tag }}
-      did-dependencies-change: ${{ steps.filter.outputs.description }}
+      did-dependencies-change: ${{ steps.filter.outputs.dependencies }}
 
     steps:
 
@@ -70,13 +70,15 @@ jobs:
             echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
           fi
 
+      # this filter is checking if the DESCRIPTION or Dockerfile-dependencies changed
       - name: Filter modified files
         id: filter
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            description:
+            dependencies:
               - 'DESCRIPTION'
+              - 'Dockerfile-dependencies'
 
       - name: Login to the Container Registry
         uses: docker/login-action@v3
@@ -89,7 +91,7 @@ jobs:
         # need bash -i to use aliases on runner
         shell: bash -ie {0}
         run: |
-          if [ "${{ steps.filter.outputs.description }}" = "true" ]; then
+          if [ "${{ steps.filter.outputs.dependencies }}" = "true" ]; then
             kaniko \
               --context $(pwd) \
               --dockerfile "Dockerfile-dependencies" \
@@ -100,6 +102,7 @@ jobs:
 
   build-pipeline-image:
 
+    if: false == true
     name: Build pipeline image
     needs: build-dependencies-image
     runs-on: cfa-cdcgov-aca

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -86,6 +86,7 @@ jobs:
           password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
+        # need bash -i to use aliases on runner
         shell: bash -ie {0}
         run: |
           if [ "${{ steps.filter.outputs.description }}" = "true" ]; then
@@ -118,6 +119,8 @@ jobs:
 
       - name: Build and push model pipeline image for Azure batch
         id: build_and_push_model_image
+        # need bash -i to use aliases on runner
+        shell: bash -ie {0}
         run: |
           if [ "${{ needs.build-dependencies-image.outputs.did-dependencies-change }}" = "true" ]; then
             echo "Dependencies changed, using branch tag"

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -69,67 +69,48 @@ jobs:
             echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
           fi
 
-      # NOTE: This lookup is only for the cache _key_. We don't need the cache _value_
-      # because we explicitly fetch image from the registry in the next step. Keeping the
-      # cached image on the runner causes the runner to quickly run out of storage.
-      - name: Check cache for base image
-        uses: actions/cache@v4
-        id: cache
-        with:
-          key: docker-dependencies-${{ runner.os }}-${{ hashFiles('./DESCRIPTION', './Dockerfile-dependencies') }}-${{ steps.image-tag.outputs.tag }}
-          lookup-only: true
-          path:
-            ./DESCRIPTION
-
-      - name: Login to the Container Registry
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: "cfaprdbatchcr.azurecr.io"
-          username: "cfaprdbatchcr"
-          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+      # - name: Login to the Container Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: "cfaprdbatchcr.azurecr.io"
+      #     username: "cfaprdbatchcr"
+      #     password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v3
-        with:
-          push: false
-          no-cache: true
-          tags: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
-          file: ./Dockerfile-dependencies
+        run: |
+          kaniko \
+            --context $(pwd) \
+            --no-push
 
-  build-pipeline-image:
-
-    name: Build pipeline image
-
-    needs: build-dependencies-image
-    runs-on: cfa-cdcgov-aca
-
-    outputs:
-      tag: ${{ needs.build-dependencies-image.outputs.tag }}
-
-    steps:
-
-      - name: Login to the Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: "cfaprdbatchcr.azurecr.io"
-          username: "cfaprdbatchcr"
-          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
-
-      - name: Build and push model pipeline image for Azure batch
-        id: build_and_push_model_image
-        uses: docker/build-push-action@v6
-        with:
-          push: false # This can be toggled manually for tweaking.
-          no-cache: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-dependencies-image.outputs.tag }}
-          file: ./Dockerfile
-          build-args: |
-            TAG=${{ needs.build-dependencies-image.outputs.tag }}
-
+  # build-pipeline-image:
+  #
+  #   name: Build pipeline image
+  #
+  #   needs: build-dependencies-image
+  #   runs-on: cfa-cdcgov-aca
+  #
+  #   outputs:
+  #     tag: ${{ needs.build-dependencies-image.outputs.tag }}
+  #
+  #   steps:
+  #
+  #     # - name: Login to the Container Registry
+  #     #   uses: docker/login-action@v3
+  #     #   with:
+  #     #     registry: "cfaprdbatchcr.azurecr.io"
+  #     #     username: "cfaprdbatchcr"
+  #     #     password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+  #
+  #     - name: Build and push model pipeline image for Azure batch
+  #       id: build_and_push_model_image
+  #       run: |
+  #         kaniko \
+  #           --context $(pwd) \
+  #           --no-push
+        #
+        #
+        #
+        #
   # batch-pool:
 
   #   name: Create Batch Pool and Submit Jobs

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -132,8 +132,8 @@ jobs:
           fi
           kaniko \
             --context $(pwd) \
-            --build-arg "TAG=$DEPENDENCY_TAG" \
             --dockerfile "Dockerfile" \
+            --build-arg "TAG=$DEPENDENCY_TAG" \
             --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
             --no-push
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -77,6 +77,7 @@ jobs:
       #     password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
+        shell: bash -ieo pipefail {0}
         run: |
           executor \
             --context $(pwd) \

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -110,6 +110,9 @@ jobs:
 
     steps:
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Login to the Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -133,6 +133,7 @@ jobs:
           kaniko \
             --context $(pwd) \
             --build-arg "TAG=$DEPENDENCY_TAG" \
+            --dockerfile "Dockerfile"
             --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
             --no-push
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push
         run: |
-          kaniko \
+          executor \
             --context $(pwd) \
             --no-push
 
@@ -104,7 +104,7 @@ jobs:
   #     - name: Build and push model pipeline image for Azure batch
   #       id: build_and_push_model_image
   #       run: |
-  #         kaniko \
+  #         executor \
   #           --context $(pwd) \
   #           --no-push
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -31,7 +31,7 @@ on:
 
 defaults:
   run:
-    shell: bash -ie {0}
+    shell: bash -ile {0}
 env:
   # Together, these form: cfaprdbatchcr.azurecr.io/cfa-epinow2-pipeline
   REGISTRY: cfaprdbatchcr.azurecr.io
@@ -183,10 +183,6 @@ jobs:
           sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
           sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
           sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
-
-      - name: Ensuring the Azure CLI is installed
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends azure-cli
 
       - name: Login to Azure with NNH Service Principal
         id: azure_login_2

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -40,10 +40,10 @@ jobs:
     runs-on: cfa-cdcgov-aca
     name: Test Python
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      # - name: Setup Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.12'
       - name: Test Python
         run: 'python3 --version'
 

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -77,8 +77,9 @@ jobs:
           password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
+        shell: bash -ie {0}
         run: |
-          executor \
+          kaniko \
             --context $(pwd) \
             --build-arg "TAG=latest" \
             --no-push

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -133,7 +133,7 @@ jobs:
           kaniko \
             --context $(pwd) \
             --build-arg "TAG=$DEPENDENCY_TAG" \
-            --dockerfile "Dockerfile"
+            --dockerfile "Dockerfile" \
             --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
             --no-push
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Test Python
         run: 'python3 --version'
 
   build-dependencies-image:

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -38,7 +38,7 @@ env:
 jobs:
 
   build-dependencies-image:
-    runs-on: cfa-cdcgov # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
+    runs-on: cfa-cdcgov-aca # VM based runner serving CFA's cdcgov repos (as opposed to cdcent)
     name: Build dependencies image
 
     outputs:
@@ -93,7 +93,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: false
           no-cache: true
           tags: |
             ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
@@ -104,7 +104,7 @@ jobs:
     name: Build pipeline image
 
     needs: build-dependencies-image
-    runs-on: cfa-cdcgov
+    runs-on: cfa-cdcgov-aca
 
     outputs:
       tag: ${{ needs.build-dependencies-image.outputs.tag }}
@@ -122,7 +122,7 @@ jobs:
         id: build_and_push_model_image
         uses: docker/build-push-action@v6
         with:
-          push: true # This can be toggled manually for tweaking.
+          push: false # This can be toggled manually for tweaking.
           no-cache: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-dependencies-image.outputs.tag }}
@@ -130,95 +130,95 @@ jobs:
           build-args: |
             TAG=${{ needs.build-dependencies-image.outputs.tag }}
 
-  batch-pool:
+  # batch-pool:
 
-    name: Create Batch Pool and Submit Jobs
-    runs-on: cfa-cdcgov
-    needs: build-pipeline-image
-    container: python:3.12
+  #   name: Create Batch Pool and Submit Jobs
+  #   runs-on: cfa-cdcgov-aca
+  #   needs: build-pipeline-image
+  #   container: python:3.12
 
-    permissions:
-      contents: read
-      packages: write
+  #   permissions:
+  #     contents: read
+  #     packages: write
 
-    env:
-      TAG: ${{ needs.build-pipeline-image.outputs.tag }}
-      # Every Azure Batch Pool parameter can simply go here,
-      # no python module or config toml necessary
-      POOL_ID: "cfa-epinow2-${{ needs.build-pipeline-image.outputs.tag }}"
-      BATCH_ACCOUNT:     "cfaprdba"
-      BATCH_ENDPOINT:    "https://cfaprdba.eastus.batch.azure.com/"
-      VM_IMAGE_TAG:      "canonical:0001-com-ubuntu-server-focal:20_04-lts"
-      NODE_AGENT_SKU_ID: "batch.node.ubuntu 20.04"
-      VM_SIZE:           "standard_a4m_v2"
-      RESOURCE_GROUP:    ${{ secrets.PRD_RESOURCE_GROUP }}
+  #   env:
+  #     TAG: ${{ needs.build-pipeline-image.outputs.tag }}
+  #     # Every Azure Batch Pool parameter can simply go here,
+  #     # no python module or config toml necessary
+  #     POOL_ID: "cfa-epinow2-${{ needs.build-pipeline-image.outputs.tag }}"
+  #     BATCH_ACCOUNT:     "cfaprdba"
+  #     BATCH_ENDPOINT:    "https://cfaprdba.eastus.batch.azure.com/"
+  #     VM_IMAGE_TAG:      "canonical:0001-com-ubuntu-server-focal:20_04-lts"
+  #     NODE_AGENT_SKU_ID: "batch.node.ubuntu 20.04"
+  #     VM_SIZE:           "standard_a4m_v2"
+  #     RESOURCE_GROUP:    ${{ secrets.PRD_RESOURCE_GROUP }}
 
-    steps:
-      - name: Checkout Repo
-        id: checkout_repo
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout Repo
+  #       id: checkout_repo
+  #       uses: actions/checkout@v4
 
-      # This step is only needed during the action to write the
-      # config file. Users can have a config file stored in their VAP
-      # sessions. In the future, we will have the config.toml file
-      # distributed with the repo (encrypted).
-      - name: Writing out config file
-        run: |
-          cat <<EOF > pool-config-${{ github.sha }}.toml
-          ${{ secrets.POOL_CONFIG_TOML }}
-          EOF
+  #     # This step is only needed during the action to write the
+  #     # config file. Users can have a config file stored in their VAP
+  #     # sessions. In the future, we will have the config.toml file
+  #     # distributed with the repo (encrypted).
+  #     - name: Writing out config file
+  #       run: |
+  #         cat <<EOF > pool-config-${{ github.sha }}.toml
+  #         ${{ secrets.POOL_CONFIG_TOML }}
+  #         EOF
 
-          # Replacing placeholders in the config file
-          sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
-          sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
-          sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
+  #         # Replacing placeholders in the config file
+  #         sed -i 's|{{ IMAGE_NAME }}|${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}|g' pool-config-${{ github.sha }}.toml
+  #         sed -i 's|{{ VM_SIZE }}|${{ env.VM_SIZE }}|g' pool-config-${{ github.sha }}.toml
+  #         sed -i 's|{{ POOL_ID }}|${{ env.POOL_ID }}|g' pool-config-${{ github.sha }}.toml
 
-      - name: Ensuring the Azure CLI is installed
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends azure-cli
+  #     - name: Ensuring the Azure CLI is installed
+  #       run: |
+  #         apt-get update && apt-get install -y --no-install-recommends azure-cli
 
-      - name: Login to Azure with NNH Service Principal
-        id: azure_login_2
-        uses: azure/login@v2
-        with:
-        # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
-          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+  #     - name: Login to Azure with NNH Service Principal
+  #       id: azure_login_2
+  #       uses: azure/login@v2
+  #       with:
+  #       # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
+  #         creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
 
-      #########################################################################
-      # Checking if the pool exists
-      # This is done via az batch pool list. If there is no pool matching the
-      # pool id (which is a function of the tag, i.e., branch name), then we
-      # pool-exists will be ''.
-      #########################################################################
-      - name: Check if pool exists
-        id: check_pool_id
-        run: |
+  #     #########################################################################
+  #     # Checking if the pool exists
+  #     # This is done via az batch pool list. If there is no pool matching the
+  #     # pool id (which is a function of the tag, i.e., branch name), then we
+  #     # pool-exists will be ''.
+  #     #########################################################################
+  #     - name: Check if pool exists
+  #       id: check_pool_id
+  #       run: |
 
-          az batch account login \
-            --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
-            --name "${{ env.BATCH_ACCOUNT }}"
+  #         az batch account login \
+  #           --resource-group ${{ secrets.PRD_RESOURCE_GROUP }} \
+  #           --name "${{ env.BATCH_ACCOUNT }}"
 
-          az batch pool list \
-            --output tsv \
-            --filter "(id eq '${{ env.POOL_ID }}')" \
-            --query "[].[id, allocationState, creationTime]" > \
-            pool-list-${{ github.sha }}
+  #         az batch pool list \
+  #           --output tsv \
+  #           --filter "(id eq '${{ env.POOL_ID }}')" \
+  #           --query "[].[id, allocationState, creationTime]" > \
+  #           pool-list-${{ github.sha }}
 
-          echo "pool-exists=$(cat pool-list-${{ github.sha }})" >> \
-            $GITHUB_OUTPUT
+  #         echo "pool-exists=$(cat pool-list-${{ github.sha }})" >> \
+  #           $GITHUB_OUTPUT
 
-      - name: Create cfa-epinow2-pipeline Pool
-        id: create_batch_pool
+  #     - name: Create cfa-epinow2-pipeline Pool
+  #       id: create_batch_pool
 
-        # This is a conditional step that will only run if the pool does not
-        # exist
-        if: ${{ steps.check_pool_id.outputs.pool-exists == '' }}
+  #       # This is a conditional step that will only run if the pool does not
+  #       # exist
+  #       if: ${{ steps.check_pool_id.outputs.pool-exists == '' }}
 
-        # The call to the az cli that actually generates the pool
-        run: |
-          # Running the python script azure/pool.py passing the config file
-          # as an argument
-          pip install -r azure/requirements.txt
-          python3 azure/pool.py \
-            pool-config-${{ github.sha }}.toml \
-            batch-autoscale-formula.txt
+  #       # The call to the az cli that actually generates the pool
+  #       run: |
+  #         # Running the python script azure/pool.py passing the config file
+  #         # as an argument
+  #         pip install -r azure/requirements.txt
+  #         python3 azure/pool.py \
+  #           pool-config-${{ github.sha }}.toml \
+  #           batch-autoscale-formula.txt

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        shell: bash -ie
+        shell: bash -ie {0}
         run: |
           executor \
             --context $(pwd) \

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -122,17 +122,18 @@ jobs:
         # need bash -i to use aliases on runner
         shell: bash -ie {0}
         run: |
+          BUILD_TAG="${{ needs.build-dependencies-image.outputs.tag }}"
           if [ "${{ needs.build-dependencies-image.outputs.did-dependencies-change }}" = "true" ]; then
             echo "Dependencies changed, using branch tag"
-            DEPENDENCY_TAG="${{ steps.image-tag.outputs.tag }}"
+            DEPENDENCY_TAG="$BUILD_TAG"
           else
             echo "No deependencies changed, using tag: latest"
-            TAG="latest"
+            DEPENDENCY_TAG="latest"
           fi
           kaniko \
             --context $(pwd) \
             --build-arg "TAG=$DEPENDENCY_TAG" \
-            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}" \
+            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
             --no-push
         #
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -95,14 +95,13 @@ jobs:
             kaniko \
               --context $(pwd) \
               --dockerfile "Dockerfile-dependencies" \
-              --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}" \
+              --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}"
           else
             echo "Skipping build and push since dependencies haven't changed"
           fi
 
   build-pipeline-image:
 
-    if: false == true
     name: Build pipeline image
     needs: build-dependencies-image
     runs-on: cfa-cdcgov-aca
@@ -139,7 +138,7 @@ jobs:
             --context $(pwd) \
             --dockerfile "Dockerfile" \
             --build-arg "TAG=$DEPENDENCY_TAG" \
-            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
+            --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" 
   batch-pool:
 
     name: Create Batch Pool and Submit Jobs

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build and push
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v3
         with:
           push: false
           no-cache: true

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -94,7 +94,6 @@ jobs:
               --context $(pwd) \
               --dockerfile "Dockerfile-dependencies" \
               --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}" \
-              --no-push
           else
             echo "Skipping build and push since dependencies haven't changed"
           fi
@@ -130,7 +129,7 @@ jobs:
             echo "Dependencies changed, using branch tag"
             DEPENDENCY_TAG="$BUILD_TAG"
           else
-            echo "No deependencies changed, using tag: latest"
+            echo "No dependencies changed, using tag: latest"
             DEPENDENCY_TAG="latest"
           fi
           kaniko \
@@ -138,7 +137,6 @@ jobs:
             --dockerfile "Dockerfile" \
             --build-arg "TAG=$DEPENDENCY_TAG" \
             --destination "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$BUILD_TAG" \
-            --no-push
         #
         #
         #

--- a/.github/workflows/containers-and-az-pool.yaml
+++ b/.github/workflows/containers-and-az-pool.yaml
@@ -69,15 +69,15 @@ jobs:
             echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
           fi
 
-      # - name: Login to the Container Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: "cfaprdbatchcr.azurecr.io"
-      #     username: "cfaprdbatchcr"
-      #     password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: "cfaprdbatchcr.azurecr.io"
+          username: "cfaprdbatchcr"
+          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        shell: bash -ieo pipefail {0}
+        shell: bash -ie pipefail {0}
         run: |
           executor \
             --context $(pwd) \

--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -6,7 +6,6 @@ COPY . pkg/
 # Installing missing dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends pandoc-citeproc
 RUN install2.r pak
-RUN echo 'changing file'
 # dependencies = TRUE means we install `suggests` too
 RUN Rscript -e 'pak::local_install_deps("pkg", upgrade = FALSE, dependencies = TRUE)'
 

--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -6,6 +6,7 @@ COPY . pkg/
 # Installing missing dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends pandoc-citeproc
 RUN install2.r pak
+RUN echo 'changing file'
 # dependencies = TRUE means we install `suggests` too
 RUN Rscript -e 'pak::local_install_deps("pkg", upgrade = FALSE, dependencies = TRUE)'
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ This initial release establishes minimal feature parity with the internal EpiNow
 ## Features
 
 * GitHub Actions to build Docker images on PR and merge to main, deploy Azure Batch environments off the built images, and tear down the environment (including images) on PR close.
+* Serverless GitHub Actions to build Docker images on PR and merge to main, deploy Azure Batch environments off the built images, and tear down the environment on PR close.
 * Comprehensive documentation of pipeline code and validation of input data, parameters, and model run configs
 * Set up comprehensive logging of model runs and handle pipeline failures to preserve logs where possible
 * Automatically download and upload inputs and outputs from Azure Blob Storage


### PR DESCRIPTION
Updated the workflow to use the new Azure Container App runner.
The new runners cannot build or run Docker containers, so we use Kaniko to build and push.
Since the runners are ephemeral, there is no more cache, so I used the paths-filter action to conditionally build the dependency image only when the DESCRIPTION or Dockerfile-dependencies change.
Finally, without Docker, the 'container: python-3.12' directive cannot be used. The runner image does have python 3.10 or 3.11 installed, but I used the actions/setup-python action to match the existing version.

Feel free to try the cfa-cdcgov-aca runner elsewhere keeping the above restrictions in mind. Let me know if there's another workflow you'd like me to look at.
Build and push took ~7 minutes: https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/13166376332/job/36747431561
Proof the registry got the image (image is untested!): 
![image](https://github.com/user-attachments/assets/03c3d4e7-60ac-4eec-9403-0fb2aeb5f7a6)
