### PR TITLE
Add the blob container name for exclusions to metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Add the blob storage container, if provided
 * Adding make command to test Azure batch
 * Updating subnet ID and pool VM to 22.04 from 20.04
 * Write model diagnostics to an output file, correcting an oversight

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -279,7 +279,10 @@ execute_model_logic <- function(config, input_dir, output_dir) {
     production_date = config@production_date,
     max_reference_date = config@max_reference_date,
     min_reference_date = config@min_reference_date,
-    exclusions = empty_str_if_non_existent(config@exclusions@path),
+    exclusions_path = empty_str_if_non_existent(config@exclusions@path),
+    exclusions_blob_container = empty_str_if_non_existent(
+      config@exclusions@blob_storage_container
+    ),
     # Add the config container here when refactoring out to outer func
     run_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z")
   )


### PR DESCRIPTION
## Nate's Summary
The metadata previously saved the path to an exclusions file (if provided). However it did not provide the name of the blob storage container (if provided). This adds that so that we can more easily see where the given exclusions file lives.

## Copilot's Summary
This pull request includes updates to the `CFAEpiNow2Pipeline` to add support for blob storage containers and to correct an oversight in the model diagnostics output. The most important changes include updates to the `NEWS.md` file and modifications to the `execute_model_logic` function in `R/pipeline.R`.

### Updates to `NEWS.md`:

* Added a note about the new feature to add the blob storage container if provided.

### Code changes in `R/pipeline.R`:

* Modified the `execute_model_logic` function to include `exclusions_blob_container` and renamed `exclusions` to `exclusions_path` for clarity.