### PR TITLE
Doc add task exclusions mpw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ config:
 	  -f state=all \
 	  -f job_id=$(JOB)
 
-run-batch: 
+run-batch:
 	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
 	$(CNTR_MGR) run --rm  \
 	--env-file .env \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,14 @@ config:
 	  -f state=all \
 	  -f job_id=$(JOB)
 
-run-batch: config
+run-batch: 
+	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
+	$(CNTR_MGR) run --rm  \
+	--env-file .env \
+	-it \
+	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+
+run-prod: config
 	@echo "Hanging for 15 seconds to wait for configs to generate"
 	sleep 15
 	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
@@ -56,11 +63,6 @@ up:
 	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
 	--env-file .env \
 	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) /bin/bash
-
-run-function:
-	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
-	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
-	Rscript -e "CFAEpiNow2Pipeline::run_pipeline('/cfa-epinow2-pipeline/configs/baa631b0a39111efbec600155d6da693_MS_Influenza_1731703176.json')"
 
 push:
 	$(CNTR_MGR) push $(REGISTRY)$(IMAGE_NAME):$(TAG)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Adding exclusions documentation and Makefile support
 * Building with ubuntu-latest
 * Add the blob storage container, if provided
 * Adding make command to test Azure batch

--- a/SOP.md
+++ b/SOP.md
@@ -1,5 +1,5 @@
 ## Epinow2 Rt Pipeline Local Run
-This document is meant to guide someone in running the weekly Rt estimation pipeline from within the VAP (Virtual Analytic Platform). The main command for running the weekly pipeline (found in the Makefile) is `make run-batch`. Running this will utilize a configuration file (.json) specified from within the associated blob storage account and will produce outputs in the `rt-epinow2-output` Azure blob storage account.
+This document is meant to guide someone in running the weekly Rt estimation pipeline from within the VAP (Virtual Analytic Platform). The main command for running the weekly pipeline (found in the Makefile) is `make run-batch`. Running this will create and utilize a suite of configuration files (.json) specified from within the associated blob storage account and will produce outputs in the `rt-epinow2-output` Azure blob storage account.
 
 ### Pre-requisites
 1. VAP environment & Account
@@ -21,8 +21,8 @@ To authenticate to the requisite Azure resources provide a `.env` file containin
 ### Test Pre-requisites are Setup
 #### Test Configuration Generation
 1. `make config`
-Running this command runs code located in the CDCgov/cfa-config-generator repository. This command creates a configuration file and saves it into the appropriate azure blob storage account.
-If you receive an error that you do not have the necessary permissions to run this command please reach out Agastya Mondal (ab59@cdc.gov) for assistance
+Running this command runs code located in the CDCgov/cfa-config-generator repository. This command creates a suite of configuration file and saves it into the appropriate azure blob storage account.
+If you receive an error that you do not have the necessary permissions to run this command please reach out Agastya Mondal (ab59@cdc.gov) for assistance.
 
 #### Test make run command
 1. The following command will test your setup for using the `CFAEpiNow2Pipeline` package. This command will run the pipeline for a single state and disease locally (using the computing power of your VAP account). This will take approximately 2 minutes.
@@ -31,7 +31,20 @@ If you receive an error that you do not have the necessary permissions to run th
  `make test-batch`
 
 ### Rt Estimation Pipeline (Production)
-If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-batch`. This command will connect to Azure Batch and setup approximately 100 unique tasks that Azure Batch will run. This command is intended to close after initializing the jobs in Azure Batch. Please open Azure Batch Explorer to view the progress of these tasks.
+If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-batch`. 
+This command will run `make config`, then followed by a docker build, and then will the `job.py` script from in Batch; you only need to run `make run-batch` all of the work is done for you inside the Makefile! In doing so you are connecting to Azure Batch and setup 102 unique tasks that Azure Batch will run. This command is intended to close after initializing the jobs in Azure Batch. Please open Azure Batch Explorer to view the progress of these tasks.
+
+#### Exclusions
+If you would like to re-run the entire pipeline with exclusions to the configurations you are able to do so. There are two main types of exclusions that users commonly will need to consider (task exclusions, and data exclusions).
+##### Task Exclusions
+Task exclusions are state and disease pairs (ex. 'NY:COVID-19)' that users can specify when running so that tasks for specified state disease pairs are not generated unnecessarily. Users can specify more than one state and disease pair, so long as they are separate by a ',' (ex. 'NY:COVID-19,WA:Influenza'). To do so, a user will need to first, generate the configuration files and specify the state:disease pair to exclude (see example below) and second, run the pipeline for these configurations. 
+1. `gh workflow run \
+          -R cdcgov/cfa-config-generator run-workload.yaml  \
+	  -f task_exclusions='NY:COVID-19'`
+2. 
+
+##### Data Exclusions
+The process for handling data exclusions is currently being finalized adn this section will be finalized in April 2025. For the current procedure please reach out to Patrick Corbett (pyv3@cdc.gov). 
 
 ### Appendix
 #### Podman

--- a/SOP.md
+++ b/SOP.md
@@ -31,19 +31,19 @@ If you receive an error that you do not have the necessary permissions to run th
  `make test-batch`
 
 ### Rt Estimation Pipeline (Production)
-If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-prod`. 
+If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-prod`.
 This command will run `make config`, then followed by a docker build, and then will the `job.py` script from in Batch; you only need to run `make run-prod` all of the work is done for you inside the Makefile! In doing so you are connecting to Azure Batch and setup 102 unique tasks that Azure Batch will run. This command is intended to close after initializing the jobs in Azure Batch. Please open Azure Batch Explorer to view the progress of these tasks.
 
 #### Exclusions
 If you would like to re-run the entire pipeline with exclusions to the configurations you are able to do so. There are two main types of exclusions that users commonly will need to consider (task exclusions, and data exclusions).
 ##### Task Exclusions
-Task exclusions are state and disease pairs (ex. 'NY:COVID-19)' that users can specify when running so that tasks for specified state disease pairs are not generated unnecessarily. Users can specify more than one state and disease pair, so long as they are separate by a ',' (ex. 'NY:COVID-19,WA:Influenza'). To do so, a user will need to first, generate the configuration files and specify the state:disease pair to exclude (see example below) and second, run the pipeline for these configurations. 
-1. `TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S"); JOB_ID=Rt-estimation-$(echo $TIMESTAMP)` 
-2. `gh workflow run -R cdcgov/cfa-config-generator run-workload.yaml -f job_id=$(echo $JOB_ID) -f task_exclusions='NY:COVID-19'` 
+Task exclusions are state and disease pairs (ex. 'NY:COVID-19)' that users can specify when running so that tasks for specified state disease pairs are not generated unnecessarily. Users can specify more than one state and disease pair, so long as they are separate by a ',' (ex. 'NY:COVID-19,WA:Influenza'). To do so, a user will need to first, generate the configuration files and specify the state:disease pair to exclude (see example below) and second, run the pipeline for these configurations.
+1. `TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S"); JOB_ID=Rt-estimation-$(echo $TIMESTAMP)`
+2. `gh workflow run -R cdcgov/cfa-config-generator run-workload.yaml -f job_id=$(echo $JOB_ID) -f task_exclusions='NY:COVID-19'`
 3. `make run-batch JOB=$(echo $JOB_ID)`
 
 ##### Data Exclusions
-The process for handling data exclusions is currently being finalized adn this section will be finalized in April 2025. For the current procedure please reach out to Patrick Corbett (pyv3@cdc.gov). 
+The process for handling data exclusions is currently being finalized adn this section will be finalized in April 2025. For the current procedure please reach out to Patrick Corbett (pyv3@cdc.gov).
 
 ### Appendix
 #### Podman

--- a/SOP.md
+++ b/SOP.md
@@ -1,5 +1,5 @@
 ## Epinow2 Rt Pipeline Local Run
-This document is meant to guide someone in running the weekly Rt estimation pipeline from within the VAP (Virtual Analytic Platform). The main command for running the weekly pipeline (found in the Makefile) is `make run-batch`. Running this will create and utilize a suite of configuration files (.json) specified from within the associated blob storage account and will produce outputs in the `rt-epinow2-output` Azure blob storage account.
+This document is meant to guide someone in running the weekly Rt estimation pipeline from within the VAP (Virtual Analytic Platform). The main command for running the weekly pipeline (found in the Makefile) is `make run-prod`. Running this will create and utilize a suite of configuration files (.json) specified from within the associated blob storage account and will produce outputs in the `rt-epinow2-output` Azure blob storage account.
 
 ### Pre-requisites
 1. VAP environment & Account
@@ -31,17 +31,16 @@ If you receive an error that you do not have the necessary permissions to run th
  `make test-batch`
 
 ### Rt Estimation Pipeline (Production)
-If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-batch`. 
-This command will run `make config`, then followed by a docker build, and then will the `job.py` script from in Batch; you only need to run `make run-batch` all of the work is done for you inside the Makefile! In doing so you are connecting to Azure Batch and setup 102 unique tasks that Azure Batch will run. This command is intended to close after initializing the jobs in Azure Batch. Please open Azure Batch Explorer to view the progress of these tasks.
+If you have succesfully setup the pre-requisites and are able to run `make config` and `make run CONGIF=test/test.json` you are ready to run the entire pipeline in production `make run-prod`. 
+This command will run `make config`, then followed by a docker build, and then will the `job.py` script from in Batch; you only need to run `make run-prod` all of the work is done for you inside the Makefile! In doing so you are connecting to Azure Batch and setup 102 unique tasks that Azure Batch will run. This command is intended to close after initializing the jobs in Azure Batch. Please open Azure Batch Explorer to view the progress of these tasks.
 
 #### Exclusions
 If you would like to re-run the entire pipeline with exclusions to the configurations you are able to do so. There are two main types of exclusions that users commonly will need to consider (task exclusions, and data exclusions).
 ##### Task Exclusions
 Task exclusions are state and disease pairs (ex. 'NY:COVID-19)' that users can specify when running so that tasks for specified state disease pairs are not generated unnecessarily. Users can specify more than one state and disease pair, so long as they are separate by a ',' (ex. 'NY:COVID-19,WA:Influenza'). To do so, a user will need to first, generate the configuration files and specify the state:disease pair to exclude (see example below) and second, run the pipeline for these configurations. 
-1. `gh workflow run \
-          -R cdcgov/cfa-config-generator run-workload.yaml  \
-	  -f task_exclusions='NY:COVID-19'`
-2. 
+1. `TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S"); JOB_ID=Rt-estimation-$(echo $TIMESTAMP)` 
+2. `gh workflow run -R cdcgov/cfa-config-generator run-workload.yaml -f job_id=$(echo $JOB_ID) -f task_exclusions='NY:COVID-19'` 
+3. `make run-batch JOB=$(echo $JOB_ID)`
 
 ##### Data Exclusions
 The process for handling data exclusions is currently being finalized adn this section will be finalized in April 2025. For the current procedure please reach out to Patrick Corbett (pyv3@cdc.gov). 


### PR DESCRIPTION
I adjusted some of the syntax in the Makefile here so we have more customizable chunks of make commands in the Makefile. i.e. 'make run-prod' will now be the command to run the weekly pipeline in production while 'make run-batch' should be run after a custom config call. 

Testing of new make commands 'make run-prod' and the 3 steps under Task Exclusions shown to work without issue