### PR TITLE
Re-activate epinow2 logging

### DIFF
--- a/R/fit_model.R
+++ b/R/fit_model.R
@@ -63,7 +63,7 @@ fit_model <- function(
         rt = rt,
         gp = gp,
         stan = stan,
-        verbose = FALSE,
+        verbose = TRUE,
         # Dump logs to console to be caught by pipeline's logging instead of
         # EpiNow2's default through futile.logger
         logs = EpiNow2::setup_logging(


### PR DESCRIPTION
## Goal
Re-activate epinow2 logs so that we can see the sampler running at the CLI when running the pipeline locally

## Background
Previously, 8e0ca96 turned off debug level logs in epinow2. However, this caused all sampler logs to stop printing to the command line. We want the sampler logs to print in real time so that we can tell if the pipeline is running or hanging when doing local test runs.

This PR reverts 8e0ca96. I did this as a separate commit rather than explicitly reverting 8e0ca96, because 8e0ca96 contained some changes to news as well.