### PR TITLE
Add data outliers rerun instructions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Add instructions for data outliers reruns to the SOP.
 * Add ability to call `make rerun-prod` to rerun just the tasks that needed a data change.
 * Add output container as a new field in the config file.
 * Building with ubuntu-latest and using Container App runner for all else, remove azure-cli action

--- a/SOP.md
+++ b/SOP.md
@@ -216,7 +216,7 @@ In this flowchart, each arrow with text represents a manual action. Writing out 
 1. Upload the file to the blob storage "folder" `az://nssp-rt-v2/outliers/`. Can be done by either:
     1. Manually uploading using the Web Portal or the Storage Explorer.
     1. Running `az storage blob upload --file /path/to/data/outliers/YYYY-MM-DD.csv --container-name nssp-rt-v2 --name outilers/YYYY-MM-DD.csv`.
-1. The person running the pipeline runs `make rerun-prod`. This will create new configuration files based on the CSV just uploaded to Blob, and then kick off those tasks in Azure Batch.
+1. The person running the pipeline runs `make rerun-prod`. This will create new configuration files that include the path to the outlier CSV just uploaded to Blob, and then kick off those tasks in Azure Batch.
 
 ## Non-production runs
 The config file uniquely defines a run. To kick off a non-production run, test,


### PR DESCRIPTION
## Nate's Summary
This adds instructions on how to rerun, as well as some context around data outlier reruns.

The rendered mermaid diagram can be [found here](https://github.com/CDCgov/cfa-epinow2-pipeline/blob/89ff6a9db14069ed60b629f8c4ddf9f9858acc10/SOP.md)

## Copilot's Summary
This pull request includes updates to the `SOP.md` file to improve clarity and provide more detailed instructions for handling data exclusions and generating configurations. The most important changes include adding a new section on data exclusions, updating instructions for generating configurations, and correcting minor formatting issues.

Enhancements to data exclusions process:

* Added a detailed explanation and flowchart for handling data exclusions during anomaly review meetings, including the steps for documenting decisions, verifying data, and running the pipeline with the updated configurations.

Updates to configuration generation instructions:

* Corrected the storage path in the instructions for generating configurations using the GUI and command line, ensuring consistency and accuracy.

Formatting improvements:

* Changed the "Getting started" section header from `#` to `##` for better readability and consistency with other sections.
