### PR TITLE
adding sleep time as parameter to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMAGE_NAME=cfa-epinow2-pipeline
 BRANCH=$(shell git branch --show-current)
 CONFIG_CONTAINER=rt-epinow2-config
 CNTR_MGR=docker
+SLEEP_TIME=400
 ifeq ($(BRANCH), main)
 TAG=latest
 else
@@ -52,8 +53,8 @@ run-batch:
 	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 run-prod: config
-	@echo "Hanging for 15 seconds to wait for configs to generate"
-	sleep 15
+	@echo "Hanging for $(SLEEP_TIME) seconds to wait for configs to generate"
+	sleep $(SLEEP_TIME)
 	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
 	$(CNTR_MGR) run --rm  \
 	--env-file .env \
@@ -61,8 +62,8 @@ run-prod: config
 	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 rerun-prod: rerun-config
-	@echo "Hanging for 15 seconds to wait for configs to generate"
-	sleep 15
+	@echo "Hanging for $(SLEEP_TIME) seconds to wait for configs to generate"
+	sleep $(SLEEP_TIME)
 	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
 	$(CNTR_MGR) run --rm  \
 	--env-file .env \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Adding sleep_time as parameter to Makefile
 * Automate creation of outlier csv for nssp-elt-2/outliers
 * Fix 'latest' tag for CI
 * Updated path for read/write of data outliers


### PR DESCRIPTION
Add sleep_time as parameter to Makefile to compensate for slow spin up times on cfa-config-generator container app