### PR TITLE
Swap job.py from running in Docker to being an inline metadata script

### DIFF
--- a/Dockerfile-batch
+++ b/Dockerfile-batch
@@ -1,6 +1,0 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm
-
-COPY azure .
-RUN uv pip install -r requirements.txt --system
-
-CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -45,25 +45,16 @@ rerun-config:
 	  -f report_date=$(REPORT_DATE)
 
 run-batch:
-	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
-	$(CNTR_MGR) run --rm  \
-	--env-file .env \
-	-it \
-	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+	uv run --env-file .env \
+	azure/job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 run-prod: config
-	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
-	$(CNTR_MGR) run --rm  \
-	--env-file .env \
-	-it \
-	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+	uv run --env-file .env \
+	azure/job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 rerun-prod: rerun-config
-	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
-	$(CNTR_MGR) run --rm  \
-	--env-file .env \
-	-it \
-	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+	uv run --env-file .env \
+	azure/job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 run:
 	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/mnt -it \
@@ -87,11 +78,8 @@ test-batch:
 	  -f state=NY \
 	  -f output_container="nssp-rt-testing" \
 	  -f job_id=$(JOB)
-	$(CNTR_MGR) build -f Dockerfile-batch -t batch . --no-cache
-	$(CNTR_MGR) run --rm  \
-	--env-file .env \
-	-it \
-	batch python job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
+	uv run --env-file .env \
+	azure/job.py "$(REGISTRY)$(IMAGE_NAME):$(TAG)" "$(CONFIG_CONTAINER)" "$(POOL)" "$(JOB)"
 
 test:
 	Rscript -e "testthat::test_local()"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Swap from `Dockerfile-batch` to using an inline-metadata script, managed by `uv`.
 * Adding dynamic logic to re-query for configs in blob
 * Automate creation of outlier csv for nssp-elt-2/outliers
 * Fix 'latest' tag for CI

--- a/SOP.md
+++ b/SOP.md
@@ -100,6 +100,7 @@ This may seem complicated, but once you have your dependencies and credentials s
     -   git (`sudo apt-get install git`)
     -   docker CLI ([follow this script](https://gist.github.com/jkislin/a575780249c3580a472e25c07d3fd68f#file-docker_setup-sh)). See the [appendix](#appendix) if you wish to use podman instead for local runs.
     -   gh CLI (`sudo apt-get install gh`)
+    -   `uv` command line tool. If not already installed, install with `curl -LsSf https://astral.sh/uv/install.sh | sh` (which does not require `sudo` permissions).
 2.  cfa-epinow2-pipeline repository in VAP
     -   Navigate to where you would like to clone the repository code
     -   Clone the repository (`git clone https://www.github.com/cdcgov/cfa-epinow2-pipeline` OR `gh auth login` and then `gh repo clone cdcgov/cfa-epinow2-pipeline`)

--- a/azure/job.py
+++ b/azure/job.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
                 f"Creating {len(task_configs)} tasks in job {job_id} on pool {pool_id}"
             )
             break
-        elif len(task_configs) == 0 and datetime.datetime.now() < end_time:
+        elif len(task_configs) == 0 and datetime.datetime.now() > end_time:
             raise ValueError("No tasks found")
 
     ###########

--- a/azure/job.py
+++ b/azure/job.py
@@ -1,16 +1,24 @@
-#!/usr/bin/env python3
-
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "azure-batch",
+#     "azure-identity",
+#     "azure-storage-blob",
+#     "msrest",
+# ]
+# ///
 import datetime
-import sys
 import os
-import uuid
+import sys
 import time
+import uuid
 
-from azure.identity import DefaultAzureCredential
 from msrest.authentication import BasicTokenAuthentication
-from azure.storage.blob import BlobServiceClient
-from azure.batch import BatchServiceClient
+
 import azure.batch.models as batchmodels
+from azure.batch import BatchServiceClient
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient
 
 blob_account = os.environ["BLOB_ACCOUNT"]
 blob_url = f"https://{blob_account}.blob.core.windows.net"
@@ -27,20 +35,20 @@ if __name__ == "__main__":
     # service that doesn't yet support Azure auth flow v2 :) :)
     # https://github.com/Azure/azure-sdk-for-python/issues/30468
     credential_v2 = DefaultAzureCredential()
-    token = {"access_token": credential_v2.get_token("https://batch.core.windows.net/.default").token}
+    token = {
+        "access_token": credential_v2.get_token(
+            "https://batch.core.windows.net/.default"
+        ).token
+    }
     credential_v1 = BasicTokenAuthentication(token)
 
-    batch_client = BatchServiceClient(
-        credentials=credential_v1,
-        batch_url=batch_url
-     )
+    batch_client = BatchServiceClient(credentials=credential_v1, batch_url=batch_url)
 
     #############
     # Set up job
     batch_job_id = pool_id
     job = batchmodels.JobAddParameter(
-        id=batch_job_id,
-        pool_info=batchmodels.PoolInformation(pool_id=pool_id)
+        id=batch_job_id, pool_info=batchmodels.PoolInformation(pool_id=pool_id)
     )
 
     try:
@@ -54,21 +62,23 @@ if __name__ == "__main__":
     ##########
     # Get tasks
     blob_service_client = BlobServiceClient(blob_url, credential_v2)
-    container_client = blob_service_client.get_container_client(container=config_container)
+    container_client = blob_service_client.get_container_client(
+        container=config_container
+    )
 
     start_time = datetime.datetime.now()
     end_time = start_time + datetime.timedelta(seconds=120)
     while datetime.datetime.now() < end_time:
         task_configs: list[str] = [
-            b.name
-            for b in container_client.list_blobs()
-            if job_id in b.name
+            b.name for b in container_client.list_blobs() if job_id in b.name
         ]
         if len(task_configs) == 0 and datetime.datetime.now() < end_time:
             print("No tasks currently found...Waiting 15 seconds to re-query")
             time.sleep(15)
         elif len(task_configs) > 0:
-            print(f"Creating {len(task_configs)} tasks in job {job_id} on pool {pool_id}")
+            print(
+                f"Creating {len(task_configs)} tasks in job {job_id} on pool {pool_id}"
+            )
             break
         elif len(task_configs) == 0 and datetime.datetime.now() < end_time:
             raise ValueError("No tasks found")
@@ -77,20 +87,25 @@ if __name__ == "__main__":
     # Set up tasks on job
     registry = os.environ["AZURE_CONTAINER_REGISTRY"]
     task_container_settings = batchmodels.TaskContainerSettings(
-        image_name=image_name,
-        container_run_options='--rm --workdir /'
+        image_name=image_name, container_run_options="--rm --workdir /"
     )
     task_env_settings = [
-        batchmodels.EnvironmentSetting(name="az_tenant_id", value=os.environ["AZURE_TENANT_ID"]),
-        batchmodels.EnvironmentSetting(name="az_client_id", value=os.environ["AZURE_CLIENT_ID"]),
-        batchmodels.EnvironmentSetting(name="az_service_principal", value=os.environ["AZURE_CLIENT_SECRET"])
+        batchmodels.EnvironmentSetting(
+            name="az_tenant_id", value=os.environ["AZURE_TENANT_ID"]
+        ),
+        batchmodels.EnvironmentSetting(
+            name="az_client_id", value=os.environ["AZURE_CLIENT_ID"]
+        ),
+        batchmodels.EnvironmentSetting(
+            name="az_service_principal", value=os.environ["AZURE_CLIENT_SECRET"]
+        ),
     ]
 
     # Run task at the admin level to be able to read/write to mounted drives
-    user_identity=batchmodels.UserIdentity(
+    user_identity = batchmodels.UserIdentity(
         auto_user=batchmodels.AutoUserSpecification(
-           scope=batchmodels.AutoUserScope.pool,
-           elevation_level=batchmodels.ElevationLevel.admin,
+            scope=batchmodels.AutoUserScope.pool,
+            elevation_level=batchmodels.ElevationLevel.admin,
         )
     )
 
@@ -101,7 +116,7 @@ if __name__ == "__main__":
             command_line=command,
             container_settings=task_container_settings,
             environment_settings=task_env_settings,
-            user_identity=user_identity
+            user_identity=user_identity,
         )
 
         batch_client.task.add(batch_job_id, task)

--- a/azure/job.py
+++ b/azure/job.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "azure-batch",
-#     "azure-identity",
-#     "azure-storage-blob",
-#     "msrest",
+#     "azure-batch==14.2.0",
+#     "azure-identity==1.21.0",
+#     "azure-storage-blob==12.25.1",
+#     "msrest==0.7.1",
 # ]
 # ///
 import datetime


### PR DESCRIPTION
## Nate's Summary
This swaps us from using the separate `Dockerfile-batch` (just for submitting to Batch) to a single [inline-metadata script](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata) with all of the necessary packages described in the metadata. We run it with `uv`, which (thankfully) takes the exact same `--env-file .env` argument as Docker for putting stuff into the environment it runs in.

I have tested this in Batch, and it runs as expected. 

Oh, and apparently `job.py` was not formatted, so this includes those formatting changes as well.

## Copilot's Summary
This pull request includes significant changes to the batch job system, primarily focusing on the removal of Dockerfile usage, updates to the Makefile for running jobs, and refactoring the `azure/job.py` script for better readability and dependency management.

### Removal of Dockerfile and Docker commands:

* Removed the `Dockerfile-batch` file, which was previously used to build the batch job container.

### Makefile updates:

* Updated the `Makefile` to replace Docker commands with direct `uv` commands for running batch jobs. This change affects the `run-batch`, `run-prod`, `rerun-prod`, and `test-batch` targets. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L48-R57) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L90-R82)

### Refactoring `azure/job.py`:

* Added metadata comments to specify required Python version and dependencies.
* Improved import statements by organizing and consolidating them.
* Refactored the token acquisition and `BatchServiceClient` initialization for better readability.
* Reformatted the `get_container_client` call and the task creation loop for better readability.
* Cleaned up the task environment settings and command line setup for better readability. [[1]](diffhunk://#diff-6e2211a1d7e29aae3476868e1a372d63065968b39c661a94b4b497f553b94468L80-R101) [[2]](diffhunk://#diff-6e2211a1d7e29aae3476868e1a372d63065968b39c661a94b4b497f553b94468L104-R119)