### PR TITLE
Pin r version to 4.4.3 for CICD

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,6 +30,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: "4.4.3"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
+          r-version: "4.4.3"
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: "4.4.3"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Features
 * Pin r-version at 4.4.3 for CI/CD
-* Fix minor typos in `SOP.md`. 
+* Fix minor typos in `SOP.md`.
 * Swap from `Dockerfile-batch` to using an inline-metadata script, managed by `uv`.
 * Adding dynamic logic to re-query for configs in blob
 * Automate creation of outlier csv for nssp-elt-2/outliers

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,8 @@
-# CFAEpiNow2Pipeline v0.2.1
-* Fix minor typos in `SOP.md`.
-
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Pin r-version at 4.4.3 for CI/CD
+* Fix minor typos in `SOP.md`. 
 * Swap from `Dockerfile-batch` to using an inline-metadata script, managed by `uv`.
 * Adding dynamic logic to re-query for configs in blob
 * Automate creation of outlier csv for nssp-elt-2/outliers


### PR DESCRIPTION
Pinning to r-version that is stable instead of latest (r-vers: 4.5 is causing issues with r-setup / build). 