### PR TITLE
Poll for config generation completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ config:
 	  -f output_container="nssp-rt-v2" \
 	  -f job_id=$(JOB) \
 	  -f report_date=$(REPORT_DATE)
+	@sleep 5
+	bash azure/poll_for_gh_status.sh
 
 rerun-config:
 	gh workflow run \
@@ -43,6 +45,8 @@ rerun-config:
 	  -f output_container="nssp-rt-v2" \
 	  -f job_id=$(JOB) \
 	  -f report_date=$(REPORT_DATE)
+	@sleep 5
+	bash azure/poll_for_gh_status.sh
 
 run-batch:
 	uv run --env-file .env \

--- a/azure/poll_for_gh_status.sh
+++ b/azure/poll_for_gh_status.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Polling for config generation completion"
+
+while true; do
+  STATUS="$(gh run list --repo cdcgov/cfa-config-generator --limit 1 --json status | jq -r '.[0].status')"
+  CONCLUSION="$(gh run list --repo cdcgov/cfa-config-generator --limit 1 --json conclusion | jq -r '.[0].conclusion')"
+
+  if [[ "$STATUS" == "completed" ]]; then
+    if [[ "$CONCLUSION" == "success" ]]; then
+      echo "Latest config generation workflow completed"
+      exit 0
+    else
+      echo "Failure: workflow failed with conclusion $(CONCLUSION)"
+      exit 1
+    fi
+  fi
+
+  echo
+  echo "Workflow status: $STATUS"
+  echo "Waiting 15 seconds and retrying"
+  echo
+  sleep 15
+done


### PR DESCRIPTION
Adds a simple shell script that hits the GH API every 15 seconds and
checks the status of the latest workflow run. It assumes that the latest
workflow run in the config generator repo is the run of interest.

I don't touch the time-delay in the `job.py` script but can if we think
it's not needed anymore.
