### PR TITLE
deleting tag from ghcr + OIDC login

### DIFF
--- a/.github/scripts/delete-container-tag.sh
+++ b/.github/scripts/delete-container-tag.sh
@@ -19,8 +19,3 @@ az acr repository delete \
     --yes \
     --name "${REGISTRY}" \
     --image "${IMAGE}:${TAG}"
-
-az acr repository delete \
-    --yes \
-    --name "${REGISTRY}" \
-    --image "${IMAGE}:dependencies-${TAG}"

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   IMAGE_NAME: cfa-epinow2-pipeline
-  IMAGE_TAG: ${{ inputs.tag || github.head_ref || github.ref_name }} 
+  IMAGE_TAG: ${{ inputs.tag || github.head_ref || github.ref_name }}
   # getting tag from input or branch name https://stackoverflow.com/a/71158878
 
 jobs:

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -1,39 +1,67 @@
-name: Delete tag from container registry
+name: Delete tag from container registries
 
 on:
   pull_request:
     types: [closed]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: The name of the tag to delete. Usually the branch name.
+        type: string
 
 env:
   IMAGE_NAME: cfa-epinow2-pipeline
+  IMAGE_TAG: ${{ inputs.tag || github.head_ref || github.ref_name }} 
+  # getting tag from input or branch name https://stackoverflow.com/a/71158878
 
 jobs:
-  delete-container:
+  delete-tag-ghcr:
+    continue-on-error: true # allow other tag deletion to happen even if one fails
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    name: Delete image tag from GHCR
+
+    steps:
+      # Deleting a package from GHCR by tag name is surprising complex
+      # This action has been approved for use on cdcent/cdcgov by the CDC Github Team
+      # https://github.com/snok/container-retention-policy
+      - name: Delete image tag
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ env.IMAGE_NAME }}
+          image-tags: ${{ env.IMAGE_TAG }},${{ env.IMAGE_TAG }}-cache
+          cut-off: 1s # required, minimum package age to be a candidate for deletion
+
+  delete-tag-acr:
+    environment: production
+    continue-on-error: true # allow other tag deletion to happen even if one fails
+    permissions:
+      id-token: write
+      contents: read
     runs-on: cfa-cdcgov-aca
-    name: Deleting the container
+    name: Delete image tag from ACR
 
     steps:
       - name : Checkout code
         uses: actions/checkout@v4
 
-      - name: Figure out tag (either latest if it is main or the branch name)
-        id: image-tag
-        run: echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-
-      - name: Login to Azure with NNH Service Principal
+      - name: Login to Azure with NNH Service Principal using OIDC
         id: azure_login_2
         uses: azure/login@v2
         with:
           # managed by EDAV. Contact Amit Mantri or Jon Kislin if you
           # have issues. Also, this is documented in the Predict
           # handbook.
-          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+          client-id: ${{ secrets.AZURE_NNHT_SP_CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Azure CLI script
         run: |
-            chmod +x $GITHUB_WORKSPACE/.github/scripts/delete-container-tag.sh
-            $GITHUB_WORKSPACE/.github/scripts/delete-container-tag.sh \
+            bash $GITHUB_WORKSPACE/.github/scripts/delete-container-tag.sh \
               ${{ secrets.CONTAINER_REGISTRY_URL }} \
               ${{ env.IMAGE_NAME }} \
-              ${{ steps.image-tag.outputs.tag }}
+              ${{ env.IMAGE_TAG }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* Automate tag deletion from ghcr.io
 * Editing of `SOP.md`
 * Pin r-version at 4.4.3 for CI/CD
 * Fix minor typos in `SOP.md`.


### PR DESCRIPTION
I updated the delete-container-tag.yaml job to delete from GHCR as well as ACR when a pull request is closed. I added an input to the workflow_dispatch so we can use the same workflow to manually clean up past images.
There are two separate jobs that are set up with `continue-on-error` so workflow can still be used if an image tag has already been removed from one of the container registries without failing the whole pipeline and cancelling the other job.
While I was in there, I switched from using the service principal secret to OIDC login (also done in #177) so we don't have to worry about rotating credentials in 2026. I also removed the dependency image tag deletion since we switched to a unified Dockerfile a while back.

I used a third-party action to delete the image tag from GHCR since Github does not make it easy using the REST API (you have to list all versions of a package, loop through the versions to find the version ID using the tag name, then send the delete request with the version ID). This action by default will also delete untagged image versions by default, so if additional commits were added to a pull request causing the image to be rebuilt and tagged with the same image, those orphaned layers would be deleted as well. I got approval from CDC Github (Boris) to use this with cdcent repos, so the same action should be good everywhere.

I used this to successfully clean up a few image tags manually: https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/14740997455