### PR TITLE
Add locked versions for future stability

### DIFF
--- a/.github/scripts/create_pool.py
+++ b/.github/scripts/create_pool.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "azure-batch==14.2.0",
-#     "azure-identity==1.21.0",
-#     "azure-mgmt-batch==18.0.0",
-#     "msrest==0.7.1",
+#     "azure-batch==14.2",
+#     "azure-identity==1.21",
+#     "azure-mgmt-batch==18.0",
+#     "msrest==0.7",
 # ]
 # ///
 """

--- a/.github/scripts/create_pool.py
+++ b/.github/scripts/create_pool.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "azure-batch",
-#     "azure-identity",
-#     "azure-mgmt-batch",
-#     "msrest",
+#     "azure-batch==14.2.0",
+#     "azure-identity==1.21.0",
+#     "azure-mgmt-batch==18.0.0",
+#     "msrest==0.7.1",
 # ]
 # ///
 """

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Lock dependencies for creating the pool
 * Saving state exclusions to nssp-rt/state_exclusions
 * Automate tag deletion from ghcr.io
 * Editing of `SOP.md`


### PR DESCRIPTION
This is also a useful time to check that the new [pool creation CI](https://github.com/CDCgov/cfa-epinow2-pipeline/pull/177) works as expected, and creates a pool for this branch.

For future reference, I was able to find the exact versions that `uv` resolved by running
```sh
uv lock --script .github/scripts/create_pool.py
```
Which produced `.github/scripts/create_pool.py.lock`. I then searched through the lock file to find the exact versions for each top-level dependency in the script itself.