### PR TITLE
Gio rm selfhosted

### DIFF
--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -51,7 +51,7 @@ jobs:
           wait_for_completion: true
           print_logs: true
           script: |
-              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'" 
+              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'"
               git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
 

--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Protect 'latest'
         run: |
-          if [ "${{ env.IMAGE_TAG }} = "latest" ]; then
+          if [ "${{ env.IMAGE_TAG }}" = "latest" ]; then
             echo "Cannot delete pool for 'latest'"
             exit 1
           fi

--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -51,8 +51,9 @@ jobs:
           wait_for_completion: true
           print_logs: true
           script: |
-              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'"
-              git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
+              CURRENT_BRANCH='${{ github.event.pull_request.head.sha || github.ref_name }}'
+              echo "Cloning repo at commit '$CURRENT_BRANCH'"
+              git clone -b $CURRENT_BRANCH https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
 
               echo "Logging into Azure CLI"

--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -1,40 +1,69 @@
 name: Tear down Batch pool
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The name of the tag to delete. Usually the branch name.
+        type: string
+
+env:
+  IMAGE_TAG: ${{ inputs.tag || github.head_ref || github.ref_name }}
+  # getting tag from input or branch name https://stackoverflow.com/a/71158878
 
 jobs:
 
   delete-pool:
-    runs-on: cfa-cdcgov-aca
+    environment: production
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
     name: Delete Batch pool
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Protect 'latest'
+        run: |
+          if [ "${{ env.IMAGE_TAG }} = "latest" ]; then
+            echo "Cannot delete pool for 'latest'"
+            exit 1
+          fi
 
-        # From: https://stackoverflow.com/a/58035262/2097171
-      - name: Extract tag
-        shell: bash
-        run: echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: branch-name
-
-      - name: Azure login
-        id: azure_login_2
-        uses: azure/login@v2
+      # From: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#requesting-the-jwt-using-the-actions-core-toolkit
+      - name: Install OIDC Client from Core Package
+        run: npm install @actions/core@1.6.0 @actions/http-client
+      - name: Get Id Token
+        uses: actions/github-script@v7
+        id: idtoken
         with:
-        # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
-          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+          script: |
+            const coredemo = require('@actions/core')
+            const id_token = await coredemo.getIDToken('api://AzureADTokenExchange')
+            coredemo.setOutput('id_token', id_token)
 
       - name: Delete pool
-        run: |
-            chmod +x $GITHUB_WORKSPACE/.github/scripts/cleanup-on-pr-close.sh
-            $GITHUB_WORKSPACE/.github/scripts/cleanup-on-pr-close.sh \
-              "${{ secrets.BATCH_ACCOUNT }}" \
-              "${{ secrets.PRD_RESOURCE_GROUP }}" \
-              "cfa-epinow2-${{ steps.branch-name.outputs.tag }}"
+        uses: CDCgov/cfa-actions/runner-action@v1.3.0
+        with:
+          github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
+          github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
+          wait_for_completion: true
+          print_logs: true
+          script: |
+              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'" 
+              git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
+              cd ${{ github.event.repository.name }}
+
+              echo "Logging into Azure CLI"
+              az login --service-principal \
+                --username ${{ secrets.AZURE_NNHT_SP_CLIENT_ID }} \
+                --tenant ${{ secrets.TENANT_ID }} \
+                --federated-token ${{ steps.idtoken.outputs.id_token }} \
+                --output none
+
+              echo "Running cleanup pool script"
+              bash .github/scripts/cleanup-on-pr-close.sh \
+                "${{ secrets.BATCH_ACCOUNT }}" \
+                "${{ secrets.PRD_RESOURCE_GROUP }}" \
+                "cfa-epinow2-${{ env.IMAGE_TAG }}"

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -71,8 +71,9 @@ jobs:
           wait_for_completion: true
           print_logs: true
           script: |
-              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'"
-              git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
+              CURRENT_BRANCH='${{ github.event.pull_request.head.sha || github.ref_name }}'
+              echo "Cloning repo at commit '$CURRENT_BRANCH'"
+              git clone -b $CURRENT_BRANCH https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
 
               echo "Logging into Azure CLI"

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -71,7 +71,7 @@ jobs:
           wait_for_completion: true
           print_logs: true
           script: |
-              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'" 
+              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'"
               git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
 
@@ -87,4 +87,3 @@ jobs:
                 ${{ secrets.CONTAINER_REGISTRY_URL }} \
                 ${{ env.IMAGE_NAME }} \
                 ${{ env.IMAGE_TAG }}
-

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Protect 'latest'
         run: |
-          if [ "${{ env.IMAGE_TAG }} = "latest" ]; then
+          if [ "${{ env.IMAGE_TAG }}" = "latest" ]; then
             echo "Cannot delete pool for 'latest'"
             exit 1
           fi

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -40,28 +40,51 @@ jobs:
     continue-on-error: true # allow other tag deletion to happen even if one fails
     permissions:
       id-token: write
-      contents: read
-    runs-on: cfa-cdcgov-aca
+    runs-on: ubuntu-latest
     name: Delete image tag from ACR
 
     steps:
-      - name : Checkout code
-        uses: actions/checkout@v4
-
-      - name: Login to Azure with NNH Service Principal using OIDC
-        id: azure_login_2
-        uses: azure/login@v2
-        with:
-          # managed by EDAV. Contact Amit Mantri or Jon Kislin if you
-          # have issues. Also, this is documented in the Predict
-          # handbook.
-          client-id: ${{ secrets.AZURE_NNHT_SP_CLIENT_ID }}
-          tenant-id: ${{ secrets.TENANT_ID }}
-          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
-
-      - name: Azure CLI script
+      - name: Protect 'latest'
         run: |
-            bash $GITHUB_WORKSPACE/.github/scripts/delete-container-tag.sh \
-              ${{ secrets.CONTAINER_REGISTRY_URL }} \
-              ${{ env.IMAGE_NAME }} \
-              ${{ env.IMAGE_TAG }}
+          if [ "${{ env.IMAGE_TAG }} = "latest" ]; then
+            echo "Cannot delete pool for 'latest'"
+            exit 1
+          fi
+
+      # From: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#requesting-the-jwt-using-the-actions-core-toolkit
+      - name: Install OIDC Client from Core Package
+        run: npm install @actions/core@1.6.0 @actions/http-client
+      - name: Get Id Token
+        uses: actions/github-script@v7
+        id: idtoken
+        with:
+          script: |
+            const coredemo = require('@actions/core')
+            const id_token = await coredemo.getIDToken('api://AzureADTokenExchange')
+            coredemo.setOutput('id_token', id_token)
+
+      - name: Delete ACR tag
+        uses: CDCgov/cfa-actions/runner-action@v1.3.0
+        with:
+          github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
+          github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
+          wait_for_completion: true
+          print_logs: true
+          script: |
+              echo "Cloning repo at commit '${{ github.event.pull_request.head.sha }}'" 
+              git clone -b ${{ github.event.pull_request.head.sha }} https://github.com/${{ github.repository }}.git
+              cd ${{ github.event.repository.name }}
+
+              echo "Logging into Azure CLI"
+              az login --service-principal \
+                --username ${{ secrets.AZURE_NNHT_SP_CLIENT_ID }} \
+                --tenant ${{ secrets.TENANT_ID }} \
+                --federated-token ${{ steps.idtoken.outputs.id_token }} \
+                --output none
+
+              echo "Running delete tag script"
+              bash .github/scripts/delete-container-tag.sh \
+                ${{ secrets.CONTAINER_REGISTRY_URL }} \
+                ${{ env.IMAGE_NAME }} \
+                ${{ env.IMAGE_TAG }}
+

--- a/.github/workflows/start-app-job.yaml
+++ b/.github/workflows/start-app-job.yaml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   start-caj:
+    environment: production
     permissions:
       id-token: 'write'
       packages: 'read'

--- a/.github/workflows/start-app-job.yaml
+++ b/.github/workflows/start-app-job.yaml
@@ -24,7 +24,7 @@ jobs:
       id-token: 'write'
       packages: 'read'
       contents: 'write'
-    runs-on: cfa-cdcgov-aca
+    runs-on: ubuntu-latest
     name: start caj
     steps:
       - name: Azure login with OIDC
@@ -32,7 +32,9 @@ jobs:
         uses: azure/login@v2
         with:
         # managed by EDAV. Contact Amit Mantri or Jon Kislin if you have issues.
-          creds: ${{ secrets.EDAV_CFA_PREDICT_NNHT_SP }}
+          client-id: ${{ secrets.AZURE_NNHT_SP_CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Get container app job template
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+* Replace remaining self-hosted runner usage with ubuntu-latest
 * Fix mismatch between R code and documentation
 * Fix production diseases
 * Add RSV specifications

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747209494,
+        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
In #177, I updated the .github/workflows/containers-and-az-pool.yaml workflow to use the runner-action on ubuntu-latest instead of the cfa-cdcgov-aca runner to comply with a request from the CDC Github team. This PR is to update the remaining workflows with the same change.

I was able to successfully run all the updated workflows:
- [.github/workflows/start-app-job.yaml](https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/15055057238/job/42318933883)
- [.github/workflows/cleanup-on-pr-close.yaml](https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/15053212015)
- [.github/workflows/delete-container-tag.yaml](https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/15053279627)