### PR TITLE
fixing tag and pool deletion workflows

### DIFF
--- a/.github/workflows/cleanup-on-pr-close.yaml
+++ b/.github/workflows/cleanup-on-pr-close.yaml
@@ -53,8 +53,9 @@ jobs:
           script: |
               CURRENT_BRANCH='${{ github.event.pull_request.head.sha || github.ref_name }}'
               echo "Cloning repo at commit '$CURRENT_BRANCH'"
-              git clone -b $CURRENT_BRANCH https://github.com/${{ github.repository }}.git
+              git clone https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
+              git checkout $CURRENT_BRANCH
 
               echo "Logging into Azure CLI"
               az login --service-principal \

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -73,8 +73,9 @@ jobs:
           script: |
               CURRENT_BRANCH='${{ github.event.pull_request.head.sha || github.ref_name }}'
               echo "Cloning repo at commit '$CURRENT_BRANCH'"
-              git clone -b $CURRENT_BRANCH https://github.com/${{ github.repository }}.git
+              git clone https://github.com/${{ github.repository }}.git
               cd ${{ github.event.repository.name }}
+              git checkout $CURRENT_BRANCH
 
               echo "Logging into Azure CLI"
               az login --service-principal \

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-* Replace remaining self-hosted runner usage with ubuntu-latest
+* Replace remaining self-hosted runner workflows with ubuntu-latest
 * Fix mismatch between R code and documentation
 * Fix production diseases
 * Add RSV specifications


### PR DESCRIPTION
Turns out you can't clone a repo at a specific commit:
https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/15071381724/job/42368337662
![image](https://github.com/user-attachments/assets/44ad9ea2-d679-4552-90bb-36e4104e2ffc)

This PR just clones the default branch and checks out the specific commit after.