### PR TITLE
Add check that docs are up to date

### DIFF
--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -10,7 +10,10 @@ on:
     branches:
       - main
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
@@ -45,6 +48,12 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+      
+      - run: |
+          Rscript -e "roxygen2::roxygenize()"
+      - name: Check that roxygen documentation is up to date
+        run: |
+          git diff --exit-code || ("::error::Documentation is not up to date. Run `roxgen2::roxygenize()` locally to re-render." && exit 1)
 
       - uses: r-lib/actions/check-r-package@v2
         with:


### PR DESCRIPTION
This is a common miss and our automated tests don't catch it. Pre-commit
doesn't have a good way of handling the re-render, so we need to do it locally.
I have a local check we can optionally run, but there's no automated check.

This implementation is inspired by:
https://github.com/posit-dev/setup-air/blob/main/.github/workflows/test.yml
