### PR TITLE
Backfill config gen, and as-of date changes

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -72,8 +72,8 @@ RightTruncation <- S7::new_class( # nolint: object_name_linter
 #' Parameters Class
 #'
 #' Holds all parameter-related configurations for the pipeline.
-#' @param as_of_date A string representing the as-of date. Formatted as
-#' "YYYY-MM-DD".
+#' @param as_of_date A string representing the date as-of which to fetch the
+#' parameters for. Formatted as "YYYY-MM-DD".
 #' @param generation_interval An instance of `GenerationInterval` class.
 #' @param delay_interval An instance of `DelayInterval` class.
 #' @param right_truncation An instance of `RightTruncation` class.

--- a/azure/generate_backfill_configs.py
+++ b/azure/generate_backfill_configs.py
@@ -1,0 +1,37 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "cfa-config-generator",
+#     "typer",
+# ]
+#
+# [tool.uv.sources]
+# cfa-config-generator = { git = "https://github.com/cdcgov/cfa-config-generator" }
+# ///
+
+from datetime import date
+from typing import Annotated
+
+import typer
+from cfa_config_generator.utils.epinow2.driver_functions import generate_backfill_config
+
+
+def main(
+    state: Annotated[str, typer.Option(help="State(s)", show_default=False)],
+    disease: Annotated[str, typer.Option(help="Disease(s)", show_default=False)],
+    str_report_dates: Annotated[
+        list[str],
+        typer.Option(help="List of ISO format report dates", show_default=False),
+    ],
+) -> None:
+    """
+    Generate and upload config files for the epinow2 pipeline.
+    """
+    # Convert report dates to date objects
+    report_dates = [date.fromisoformat(date_str) for date_str in str_report_dates]
+
+    print(report_dates)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/azure/generate_backfill_configs.py
+++ b/azure/generate_backfill_configs.py
@@ -20,15 +20,71 @@ def main(
     state: Annotated[str, typer.Option(help="State(s)", show_default=False)],
     disease: Annotated[str, typer.Option(help="Disease(s)", show_default=False)],
     str_report_dates: Annotated[
-        list[str],
-        typer.Option(help="List of ISO format report dates", show_default=False),
+        str,
+        typer.Option(
+            help="List of comma separated ISO format report dates",
+            show_default=False,
+        ),
     ],
+    reference_date_time_span: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "A string representing the time span for the earliest reference date relative to"
+                " the report date. This should be formatted following the conventions of polars"
+                " `.dt.offset_by()`. Usually, this will be a string like '8w' or '1d' (for 8 weeks"
+                " or 1 day)."
+            ),
+            show_default=False,
+        ),
+    ],
+    data_paths: Annotated[
+        str | None,
+        typer.Option(
+            help=(
+                "A comma separated list of paths to the data. One path for each report date. "
+                "If the data is in blob, these should be the names of the blobs. "
+                "Cannot be used in conjunction with the --report-date-fstring option."
+            ),
+        ),
+    ] = None,
+    report_date_fstring: Annotated[
+        str | None,
+        typer.Option(
+            help=(
+                "A string representing the f-string format for data paths. "
+                "The '{}' section will be replaced with the report date "
+                "for each report date. This is most useful when pulling from the NSSP gold "
+                "data. For example, 'gold/{}.parquet' would become 'gold/2025-01-01.parquet' "
+                "for the report date 2025-01-01. "
+                "Cannot be used in conjunction with the --data-paths option."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Generate and upload config files for the epinow2 pipeline.
     """
-    # Convert report dates to date objects
-    report_dates = [date.fromisoformat(date_str) for date_str in str_report_dates]
+    # Split on commas and spaces, and remove empty strings
+    # This will handle cases like "2025-01-01, 2025-01-02 2025-01-03,2025-01-04".
+    # Then parse each date string into a date object.
+    report_dates: list[date] = [
+        date.fromisoformat(s2)
+        for s1 in str_report_dates.split(",")
+        for s2 in s1.split(" ")
+        if s2
+    ]
+
+    # Check if both data_paths and report_date_fstring are provided, and error out if so
+    if data_paths and report_date_fstring:
+        raise ValueError(
+            "Cannot use both --data-paths and --report-date-fstring options at the same time."
+        )
+    # Check that at least one of data_paths or report_date_fstring is provided
+    if not data_paths and not report_date_fstring:
+        raise ValueError(
+            "Must provide either --data-paths or --report-date-fstring option."
+        )
 
     print(report_dates)
 

--- a/azure/generate_backfill_configs.py
+++ b/azure/generate_backfill_configs.py
@@ -17,8 +17,26 @@ from cfa_config_generator.utils.epinow2.driver_functions import generate_backfil
 
 
 def main(
-    state: Annotated[str, typer.Option(help="State(s)", show_default=False)],
-    disease: Annotated[str, typer.Option(help="Disease(s)", show_default=False)],
+    state: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "State(s). Can be '*', 'all', a single state, or"
+                " multiple states, separated by commas."
+            ),
+            show_default=False,
+        ),
+    ],
+    disease: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Disease(s). Can be '*', 'all', a single disease, or"
+                " multiple diseases, separated by commas."
+            ),
+            show_default=False,
+        ),
+    ],
     str_report_dates: Annotated[
         str,
         typer.Option(
@@ -38,20 +56,47 @@ def main(
             show_default=False,
         ),
     ],
-    data_paths: Annotated[
-        str | None,
+    data_container: Annotated[
+        str,
         typer.Option(
             help=(
-                "A comma separated list of paths to the data. One path for each report date. "
-                "If the data is in blob, these should be the names of the blobs. "
-                "Cannot be used in conjunction with the --report-date-fstring option."
+                "The name of the blob storage container for input data. "
+                "Usually 'nssp-etl'"
             ),
+            show_default=False,
         ),
-    ] = None,
+    ],
+    backfill_name: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Name of the backfill run. This will be used to generate the job IDs for each"
+                "report date in the format `<backfill_name>_<report_date>`."
+            ),
+            show_default=False,
+        ),
+    ],
+    output_container: Annotated[
+        str,
+        typer.Option(
+            help=("Blob storage container to store model output."),
+            show_default=False,
+        ),
+    ],
+    str_as_of_dates: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "The parameter as-of dates. Default is to match the report dates. "
+                "Otherwise, a comma separated list of dates in ISO format. "
+            )
+        ),
+    ] = "match_report_dates",
     report_date_fstring: Annotated[
         str | None,
         typer.Option(
             help=(
+                "Use this option over --str-data-paths most of the time. "
                 "A string representing the f-string format for data paths. "
                 "The '{}' section will be replaced with the report date "
                 "for each report date. This is most useful when pulling from the NSSP gold "
@@ -59,6 +104,25 @@ def main(
                 "for the report date 2025-01-01. "
                 "Cannot be used in conjunction with the --data-paths option."
             ),
+        ),
+    ] = None,
+    str_data_paths: Annotated[
+        str | None,
+        typer.Option(
+            help=(
+                "Comma separated paths to the data. One path for each report date. "
+                "If the data is in blob, these should be the names of the blobs. "
+                "Cannot be used in conjunction with the --report-date-fstring option."
+            ),
+        ),
+    ] = None,
+    task_exclusions: Annotated[
+        str | None,
+        typer.Option(
+            help=(
+                "Comma separated state:disease pairs."
+                " Will be applied to all report dates."
+            )
         ),
     ] = None,
 ) -> None:
@@ -69,24 +133,45 @@ def main(
     # This will handle cases like "2025-01-01, 2025-01-02 2025-01-03,2025-01-04".
     # Then parse each date string into a date object.
     report_dates: list[date] = [
-        date.fromisoformat(s2)
-        for s1 in str_report_dates.split(",")
-        for s2 in s1.split(" ")
-        if s2
+        date.fromisoformat(s.strip()) for s in str_report_dates.split(",")
     ]
 
     # Check if both data_paths and report_date_fstring are provided, and error out if so
-    if data_paths and report_date_fstring:
+    if str_data_paths and report_date_fstring:
         raise ValueError(
             "Cannot use both --data-paths and --report-date-fstring options at the same time."
         )
     # Check that at least one of data_paths or report_date_fstring is provided
-    if not data_paths and not report_date_fstring:
+    if (not str_data_paths) and (not report_date_fstring):
         raise ValueError(
             "Must provide either --data-paths or --report-date-fstring option."
         )
 
-    print(report_dates)
+    # If data_paths is provided, split on commas and remove empty strings
+    data_paths: list[str] = (
+        [s.strip() for s in str_data_paths.split(",")]
+        if str_data_paths and (not report_date_fstring)
+        else [report_date_fstring.format(report_date) for report_date in report_dates]  # type: ignore
+    )
+
+    as_of_dates: list[date] = (
+        [date.fromisoformat(s.strip()) for s in str_as_of_dates.split(",")]
+        if str_as_of_dates != "match_report_dates"
+        else report_dates
+    )
+
+    generate_backfill_config(
+        state=state,
+        disease=disease,
+        report_dates=report_dates,
+        reference_date_time_span=reference_date_time_span,
+        data_paths=data_paths,
+        data_container=data_container,
+        backfill_name=backfill_name,
+        as_of_dates=as_of_dates,
+        output_container=output_container,
+        task_exclusions=task_exclusions,
+    )
 
 
 if __name__ == "__main__":

--- a/azure/generate_configs.py
+++ b/azure/generate_configs.py
@@ -52,11 +52,7 @@ def main(
     report_date: date = date.fromisoformat(report_date_str)
     production_date: date = date.fromisoformat(production_date_str)
     # Use the report date to generate the as_of_date string.
-    as_of_datetime_str: str = (
-        datetime(report_date.year, report_date.month, report_date.day)
-        .replace(tzinfo=timezone.utc)
-        .isoformat()
-    )
+    as_of_date_str: str = report_date.isoformat()
 
     # Make sure the job ID is not empty.
     if not job_id:
@@ -75,7 +71,7 @@ def main(
         data_container=input_container,
         production_date=production_date,
         job_id=job_id,
-        as_of_date=as_of_datetime_str,
+        as_of_date=as_of_date_str,
         output_container=output_container,
     )
 

--- a/azure/generate_configs.py
+++ b/azure/generate_configs.py
@@ -51,7 +51,12 @@ def main(
     """
     report_date: date = date.fromisoformat(report_date_str)
     production_date: date = date.fromisoformat(production_date_str)
-    now: datetime = datetime.now(timezone.utc)
+    # Use the report date to generate the as_of_date string.
+    as_of_datetime_str: str = (
+        datetime(report_date.year, report_date.month, report_date.day)
+        .replace(tzinfo=timezone.utc)
+        .isoformat()
+    )
 
     # Make sure the job ID is not empty.
     if not job_id:
@@ -70,7 +75,7 @@ def main(
         data_container=input_container,
         production_date=production_date,
         job_id=job_id,
-        as_of_date=now.isoformat(),
+        as_of_date=as_of_datetime_str,
         output_container=output_container,
     )
 


### PR DESCRIPTION
## Nate's Summary
This aims to do issues:
- #270 
- #276 

## Copilot's Summary
This pull request introduces improvements to configuration handling and script functionality for generating pipeline configurations. Key changes include updating parameter descriptions, adding a new script for backfill configuration generation, and refining the logic for determining `as_of_date` in an existing script.

### Parameter and Documentation Updates:
* Updated the description of the `as_of_date` parameter in the `RightTruncation` class to clarify its purpose and formatting. (`R/config.R`, [R/config.RL75-R76](diffhunk://#diff-dfde44415c21fcca29ffcce07d280c99d9506bebec4f4b2e639d8289e571c3deL75-R76))

### New Script Addition:
* Added a new Python script `azure/generate_backfill_configs.py` to generate and upload configuration files for the `epinow2` pipeline. This script introduces several command-line options for flexibility, such as specifying states, diseases, report dates, and data paths. (`azure/generate_backfill_configs.py`, [azure/generate_backfill_configs.pyR1-R178](diffhunk://#diff-4a94b5a0eae3097877fb038d038f1e69c49ce3ae4a084e7aed3d0fd33bb529a9R1-R178))

### Logic Refinements in Existing Script:
* Updated the `main` function in `azure/generate_configs.py` to use the `report_date` instead of the current date (`now`) for generating the `as_of_date` string, ensuring consistency in configuration generation. (`azure/generate_configs.py`, [[1]](diffhunk://#diff-24835e76bc3d9684a677563ca85d9e7bfad6a0ba047a49ed36ace70ff9d9df47L54-R55) [[2]](diffhunk://#diff-24835e76bc3d9684a677563ca85d9e7bfad6a0ba047a49ed36ace70ff9d9df47L73-R74)