### PR TITLE
Convert "Drop Date(s)

### DIFF
--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -41,6 +41,7 @@ read_process_excel_func <- function(
     "drop_dates",
     "additional_reasoning"
   )
+  df <- df |> dplyr::mutate(drop_dates = as.character(drop_dates))
   df <- data.frame(tidyr::separate_rows(df, 10, sep = "\\|")) |>
     dplyr::filter(!is.na(state)) |>
     dplyr::mutate(


### PR DESCRIPTION
Convert "Drop Date(s)" Column Values in Rt_Review Excel to string/character. Occasionally reads in as double. Editing template doesn't seem to address this. Simple fix, just adding in line to convert column value to character.