### PR TITLE
Convert "Drop Date(s)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
-
+* convert drop cols value to character for point/state exlcusions
 * Run `make test-batch` target locally
 * Update runner action version
 * Remove duplicate batch autoscale text file

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -27,7 +27,7 @@ read_process_excel_func <- function(
     paste0(file_name), # path where saved
     sheet = sheet_name,
     skip = 3,
-    col_names =c(
+    col_names = c(
       "state",
       "dates_affected",
       "observed volume",

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -28,18 +28,18 @@ read_process_excel_func <- function(
     sheet = sheet_name,
     skip = 3,
     col_names =c(
-    "state",
-    "dates_affected",
-    "observed volume",
-    "expected volume",
-    "initial_thoughts",
-    "state_abb",
-    "review_1_decision",
-    "reviewer_2_decision",
-    "final_decision",
-    "drop_dates",
-    "additional_reasoning"
-    )
+      "state",
+      "dates_affected",
+      "observed volume",
+      "expected volume",
+      "initial_thoughts",
+      "state_abb",
+      "review_1_decision",
+      "reviewer_2_decision",
+      "final_decision",
+      "drop_dates",
+      "additional_reasoning"
+      )
   )
   df <- df |> dplyr::mutate(drop_dates = as.character(drop_dates))
   df <- data.frame(tidyr::separate_rows(df, 10, sep = "\\|")) |>

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -26,9 +26,8 @@ read_process_excel_func <- function(
   df <- readxl::read_excel(
     paste0(file_name), # path where saved
     sheet = sheet_name,
-    skip = 3
-  )
-  colnames(df) <- c(
+    skip = 3,
+    col_names =c(
     "state",
     "dates_affected",
     "observed volume",
@@ -40,6 +39,7 @@ read_process_excel_func <- function(
     "final_decision",
     "drop_dates",
     "additional_reasoning"
+    )
   )
   df <- df |> dplyr::mutate(drop_dates = as.character(drop_dates))
   df <- data.frame(tidyr::separate_rows(df, 10, sep = "\\|")) |>

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -41,6 +41,7 @@ read_process_excel_func <- function(
     "drop_dates",
     "additional_reasoning"
   )
+  df <- df |> dplyr::mutate(drop_dates = as.character(drop_dates))
   df <- data.frame(tidyr::separate_rows(df, 10, sep = "\\|")) |>
     dplyr::filter(!is.na(state)) |>
     dplyr::mutate(

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -39,7 +39,7 @@ read_process_excel_func <- function(
       "final_decision",
       "drop_dates",
       "additional_reasoning"
-      )
+    )
   )
   df <- df |> dplyr::mutate(drop_dates = as.character(drop_dates))
   df <- data.frame(tidyr::separate_rows(df, 10, sep = "\\|")) |>


### PR DESCRIPTION
Convert "Drop Date(s)" Column Values in Rt_Review Excel to string/character. Occasionally reads in as double. Editing template doesn't seem to address this. Simple fix, just adding in line to convert column value to character.