### PR TITLE
removes nulls that are produced in outliers.csv file 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@
 * Minor changes in removing unused container tags from Azure CR
 * Reactivated DEBUG level logs from EpiNow2 so that sampler progress is visible
 * Added new test data and unit tests for point exclusions
+* Removed any nulls from reference_date column in outlier files
 
 # CFAEpiNow2Pipeline v0.1.0
 

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -123,6 +123,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     # point exclusions in outlier.csv format
     point_exclusions <- combined_df |>
       dplyr::filter(!is.na(drop_dates)) |>
+      dplyr::filter(!is.na(reference_date)) |>
       dplyr::mutate(
         raw_confirm = NA,
         clean_confirm = NA
@@ -188,6 +189,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     # Can get rid of this once we end old pipeline support
     point_exclusions <- combined_df |>
       dplyr::filter(!is.na(drop_dates)) |>
+      dplyr::filter(!is.na(reference_date)) |>
       dplyr::mutate(
         raw_confirm = NA,
         clean_confirm = NA


### PR DESCRIPTION
These code changes should remove nulls associated with reference_dates whenever we produce the outlier csvs.
![image](https://github.com/user-attachments/assets/f3b542ff-20af-4a9f-a75e-8f180300d727)
