### PR TITLE
only saves point exclusions file if data values are present

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Unsaves outlier csv files if contents are empty
 * Refactoring unit tests to make use of setup.R global testing env
 * Adding dependencies to install cmdstanr backend and using GH action
 * convert drop cols value to character for point/state exlcusions

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -137,10 +137,11 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     container_name <- "nssp-etl"
     cont <- CFAEpiNow2Pipeline::fetch_blob_container(container_name)
 
-    if point_exclusions.filter(~col("reference_date")).count() = 0:
+    df2 <- point_exclusions
+    if df2.filter(~col("reference_date")).count() == 0:
        print("Dataset is empty. Not saving.")
     else:
-       point_exclusions.show()
+       df2.show()
                                
     cli::cli_alert_info(
       "saving {lubridate::ymd(report_date)}.csv in
@@ -148,7 +149,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     )
     AzureStor::storage_write_csv(
       cont = cont,
-      object = point_exclusions,
+      object = df2,
       file = file.path(
         "outliers-v2",
         paste0(lubridate::ymd(report_date), ".csv")

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -137,6 +137,10 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     container_name <- "nssp-etl"
     cont <- CFAEpiNow2Pipeline::fetch_blob_container(container_name)
 
+    if (point_exclusions.empty){
+       print("Dataset is empty. Not saving.")
+       return None
+    }
     cli::cli_alert_info(
       "saving {lubridate::ymd(report_date)}.csv in
       {container_name}/outliers-v2"

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -141,24 +141,22 @@ create_pt_excl_from_rt_xslx <- function(dates) {
       all(df2 == "")
     }
     
-    if(empty_df(point_exclusions)){
+    if (empty_df(point_exclusions)){
       cat("This CSV contains empty values. No output file created.\n")
     } else {
-      point_exclusions
-    }
-                               
-    cli::cli_alert_info(
-      "saving {lubridate::ymd(report_date)}.csv in
-      {container_name}/outliers-v2"
-    )
-    AzureStor::storage_write_csv(
-      cont = cont,
-      object = point_exclusions,
-      file = file.path(
-        "outliers-v2",
-        paste0(lubridate::ymd(report_date), ".csv")
+      cli::cli_alert_info(
+        "saving {lubridate::ymd(report_date)}.csv in
+        {container_name}/outliers-v2"
       )
-    )
+      AzureStor::storage_write_csv(
+        cont = cont,
+        object = point_exclusions,
+        file = file.path(
+          "outliers-v2",
+          paste0(lubridate::ymd(report_date), ".csv")
+        )
+      )
+    }
 
     #### State exclusions #####
     state_exclusions <- combined_df |>

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -137,10 +137,11 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     container_name <- "nssp-etl"
     cont <- CFAEpiNow2Pipeline::fetch_blob_container(container_name)
 
-    if (point_exclusions.empty){
+    if point_exclusions.filter(~col("reference_date")).count() = 0:
        print("Dataset is empty. Not saving.")
-       return None
-    }
+    else:
+       point_exclusions.show()
+                               
     cli::cli_alert_info(
       "saving {lubridate::ymd(report_date)}.csv in
       {container_name}/outliers-v2"

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -153,7 +153,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     )
     AzureStor::storage_write_csv(
       cont = cont,
-      object = df2,
+      object = point_exclusions,
       file = file.path(
         "outliers-v2",
         paste0(lubridate::ymd(report_date), ".csv")

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -137,11 +137,15 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     container_name <- "nssp-etl"
     cont <- CFAEpiNow2Pipeline::fetch_blob_container(container_name)
 
-    df2 <- point_exclusions
-    if df2.filter(~col("reference_date")).count() == 0:
-       print("Dataset is empty. Not saving.")
-    else:
-       df2.show()
+    empty_df <- function(df2) {
+      all(df2 == "")
+    }
+    
+    if(empty_df(point_exclusions)){
+      cat("This CSV contains empty values. No output file created.\n")
+    } else {
+      point_exclusions
+    }
                                
     cli::cli_alert_info(
       "saving {lubridate::ymd(report_date)}.csv in


### PR DESCRIPTION
This update prevents saving the point exclusions file if the values under the column names are empty. This continues to save the point exclusions file if values are present. 
We have a comparison of code output from 20240514 (where no values are present) to 20240611 (where values are present)
![image](https://github.com/user-attachments/assets/3ee1bc88-633e-4b69-b96d-d3747b557052)
![image](https://github.com/user-attachments/assets/e2c64f9f-534f-4c8c-ad69-dfacb160bb04)




