### PR TITLE
save point exclusions file only if data values are present

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Does not save outlier csv files if contents are empty
 * Switching base rocker image from geospatial (4.7 GB) to r-ver (3 GB)
 * Refactoring unit tests to make use of setup.R global testing env
 * Adding dependencies to install cmdstanr backend and using GH action

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -141,7 +141,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
       all(df2 == "")
     }
 
-    if (empty_df(point_exclusions)){
+    if (empty_df(point_exclusions)) {
       cat("This CSV contains empty values. No output file created.\n")
     } else {
       cli::cli_alert_info(

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -142,7 +142,9 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     }
 
     if (empty_df(point_exclusions)) {
-      cli::cli_alert_info("This CSV contains empty values. No output file created.")
+      cli::cli_alert_info(
+        "This CSV contains empty values. No output file created."
+      )
     } else {
       cli::cli_alert_info(
         "saving {lubridate::ymd(report_date)}.csv in

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -137,18 +137,26 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     container_name <- "nssp-etl"
     cont <- CFAEpiNow2Pipeline::fetch_blob_container(container_name)
 
-    cli::cli_alert_info(
-      "saving {lubridate::ymd(report_date)}.csv in
-      {container_name}/outliers-v2"
-    )
-    AzureStor::storage_write_csv(
-      cont = cont,
-      object = point_exclusions,
-      file = file.path(
-        "outliers-v2",
-        paste0(lubridate::ymd(report_date), ".csv")
+    empty_df <- function(df2) {
+      all(df2 == "")
+    }
+
+    if (empty_df(point_exclusions)){
+      cat("This CSV contains empty values. No output file created.\n")
+    } else {
+      cli::cli_alert_info(
+        "saving {lubridate::ymd(report_date)}.csv in
+        {container_name}/outliers-v2"
       )
-    )
+      AzureStor::storage_write_csv(
+        cont = cont,
+        object = point_exclusions,
+        file = file.path(
+          "outliers-v2",
+          paste0(lubridate::ymd(report_date), ".csv")
+        )
+      )
+    }
 
     #### State exclusions #####
     state_exclusions <- combined_df |>

--- a/utils/Rt_review_exclusions.R
+++ b/utils/Rt_review_exclusions.R
@@ -142,7 +142,7 @@ create_pt_excl_from_rt_xslx <- function(dates) {
     }
 
     if (empty_df(point_exclusions)) {
-      cat("This CSV contains empty values. No output file created.\n")
+      cli::cli_alert_info("This CSV contains empty values. No output file created.")
     } else {
       cli::cli_alert_info(
         "saving {lubridate::ymd(report_date)}.csv in


### PR DESCRIPTION
This update prevents saving the point exclusions file if the values under the column names are empty. This continues to save the point exclusions file if values are present.
We have a comparison of code output from 20240514 (where no values are present) to 20240611 (where values are present)
![image](https://github.com/user-attachments/assets/65e32841-82ab-4056-97ad-477b9733f6c3)
![image](https://github.com/user-attachments/assets/d3ed5ce7-62bf-4928-b5e2-923bef012091)
