### PR TITLE
344 create dynamic low case count thresholds

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -61,7 +61,7 @@ extract_diagnostics <- function(
   if (disease == "COVID-19") {
     low_case_count_threshold = covid_low_case_count
   }
-  if(disease=="RSV"){
+  if (disease == "RSV") {
     low_case_count_threshold = covid_lorsv_low_case_countw_case_count
   }
   if (disease == "Influenza") {


### PR DESCRIPTION
See Issue: https://github.com/CDCgov/cfa-epinow2-pipeline/issues/344

Goal is to add parameters to determine the threshold value at which a specific pathogen-jurisdiction-date set will be be flagged with a n_low_case_count flag in the diagnostic file. If this flag is present, that pathogen-jurisdiction pair will have Rt estimates nulled and the growth category set to "Not Estimated" in the post-processing repo. 

The default threshold is if the pathogen-jurisdiction pair has less then 10 cases in the past week and the week prior to that. 

To add these thresholds I added three command line arguments (see below) with the intention to add these into the config file generated by the config generator and to subsequently read them into the functions within diagnostics.R where the final low case count threshold value will be determined by if statements mapping the final value to one of the below based on the pathogen in the given run.
1. covid_low_case_count
2. rsv_low_case_count
3. flu_low_case_count

This PR is accompanied by another PR in the config generator repo https://github.com/CDCgov/cfa-config-generator/pull/72