### PR TITLE
update make file with CI practices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,16 +97,16 @@ test: ## Run unit tests for the CFAEpiNow2Pipeline R package
 	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
 	--env-file .env \
 	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
-	Rscript -e "testthat::test_local()"
+	Rscript -e "testthat::test_local('cfa-epinow2-pipeline')"
 
 document: ## Generate roxygen2 documentation for the CFAEpiNow2Pipeline R package
 	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
 	--env-file .env \
 	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
-	Rscript -e "roxygen2::roxygenize()"
+	Rscript -e "roxygen2::roxygenize('cfa-epinow2-pipeline')"
 
 check: ## Perform R CMD check for the CFAEpiNow2Pipeline R package
 	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
 	--env-file .env \
 	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
-	Rscript -e "rcmdcheck::rcmdcheck()"
+	Rscript -e "rcmdcheck::rcmdcheck('cfa-epinow2-pipeline')"

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,19 @@ test-batch: ## Run GitHub Actions workflow and then job.py for testing on Azure 
 			--job_id="$(JOB)"
 
 test: ## Run unit tests for the CFAEpiNow2Pipeline R package
+	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
+	--env-file .env \
+	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
 	Rscript -e "testthat::test_local()"
 
 document: ## Generate roxygen2 documentation for the CFAEpiNow2Pipeline R package
+	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
+	--env-file .env \
+	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
 	Rscript -e "roxygen2::roxygenize()"
 
 check: ## Perform R CMD check for the CFAEpiNow2Pipeline R package
+	$(CNTR_MGR) run --mount type=bind,source=$(PWD),target=/cfa-epinow2-pipeline -it \
+	--env-file .env \
+	--rm $(REGISTRY)$(IMAGE_NAME):$(TAG) \
 	Rscript -e "rcmdcheck::rcmdcheck()"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Updating make commands to be called from docker image locally
 * Updating pre-commit to block specific test.parquet file
 * Scheduling `make run-prod` on Github Actions Wednesdays at 8 AM ET
 * Adds facility active proportion information for config runs and re-runs


### PR DESCRIPTION
We've recently had issues with developers running 'make document' locally without entering the docker image (this means it is being run from their global R environment in their VAP). This has caused some issues with documentation.
This will make these commands unified for all users running in their VAP.
This make command will make it more explicit that CI processes / checks should be run from the docker image if run locally.

To test, please run. 
1. make document