### PR TITLE
Move production run earlier

### DIFF
--- a/.github/workflows/run-prod.yaml
+++ b/.github/workflows/run-prod.yaml
@@ -2,7 +2,8 @@ name: make run-prod (or custom)
 
 on:
   schedule:
-    - cron: '0 13 * * 3'
+    # Run at 11 AM UTC on Wednesdays
+    - cron: '0 11 * * 3'
   workflow_dispatch:
     inputs:
       command:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CFAEpiNow2Pipeline v0.2.0
 
 ## Features
+* Move first run earlier in the day
 * Removing duplicative r-cmd-check.yaml file (already checking in Dockerfile)
 * Upgrade checkout action to v5
 * Updating github-script action to v8


### PR DESCRIPTION
This change moves the time of the production run up to 11 AM UTC.
This adjustment in timing should reduce the number of hours needed
to wait for runs to complete, requiring less time to maintain
production activities.

This timing is the same as for the HGAM runs, which have been
successful for multiple weeks now.
