### PR TITLE
Patched insecure workflow trigger

### DIFF
--- a/.github/workflows/dependabot-news-md-autofill.yaml
+++ b/.github/workflows/dependabot-news-md-autofill.yaml
@@ -1,7 +1,7 @@
 name: Dependabot NEWS.md autofill
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
 


### PR DESCRIPTION
@boris-ning-usds pointed out that this pull_request_target trigger is a potential vulnerability in an open repo (see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

Let's merge this patch quickly and then discuss next week:
(1) Make sure everyone knows not to use this trigger in CDCGov in the future
(2) What should be the permanent fix? (Is this workflow essential?)